### PR TITLE
HTTP requests for remote parameter values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.7.0
 ## Added
 * Add jsdoc-style docs to classes mentioned in the README
+* Add option to get variable values from HTTP requests
 
 ## Fixed
 * Improve guiUtils.filterExtraProperties() when using template merging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Added
 * Add jsdoc-style docs to classes mentioned in the README
 * Add option to get variable values from HTTP requests
+* Add Template.forwardHttp() to forward a rendered template result to an HTTP server
 
 ## Fixed
 * Improve guiUtils.filterExtraProperties() when using template merging

--- a/lib/http_utils.js
+++ b/lib/http_utils.js
@@ -23,10 +23,14 @@ const makeRequest = (opts, payload) => {
             res.on('end', () => {
                 let body = buffer.join('');
                 body = body || '{}';
-                try {
-                    body = JSON.parse(body);
-                } catch (e) {
-                    return reject(new Error(`Invalid response object from ${combOpts.method} to ${combOpts.path}`));
+                if (combOpts.headers && combOpts.headers['Content-Type'] === 'application/json') {
+                    try {
+                        body = JSON.parse(body);
+                    } catch (e) {
+                        return reject(
+                            new Error(`Invalid response object from ${combOpts.method} to ${combOpts.path}`)
+                        );
+                    }
                 }
                 return resolve({
                     status: res.statusCode,

--- a/lib/template.js
+++ b/lib/template.js
@@ -115,6 +115,7 @@ class Template {
         this._allOf = [];
         this._anyOf = [];
         this.contentType = 'text/plain';
+        this.httpForward = null;
     }
 
     _loadTypeSchemas(schemaProvider) {
@@ -815,6 +816,34 @@ class Template {
             .then(() => this.fetchHttp())
             .then(httpView => Object.assign({}, parameters, httpView))
             .then(combParams => this.render(combParams));
+    }
+
+    forwardHttp(parameters) {
+        if (!this.httpForward) {
+            return Promise.reject(
+                new Error('httpForward was not defined for this template')
+            );
+        }
+
+        const defaultOpts = {
+            method: 'POST',
+            host: null,
+            port: null,
+            headers: {
+                'Content-Type': this.contentType
+            }
+        };
+        const urlOpts = (typeof this.httpForward.url === 'string') ? url.parse(this.httpForward.url) : this.httpForward.url;
+        const opts = Object.assign({}, defaultOpts, urlOpts);
+        return Promise.resolve()
+            .then(() => this.fetchAndRender(parameters))
+            .then(() => httpUtils.makeRequest(opts))
+            .then((res) => {
+                if (res.statusCode >= 400) {
+                    return Promise.reject(new Error(`error forwarding to ${this.httpForward.url}: ${res.statusCode}`));
+                }
+                return Promise.resolve(res);
+            });
     }
 }
 

--- a/lib/template.js
+++ b/lib/template.js
@@ -9,6 +9,7 @@ const $RefParser = require('@apidevtools/json-schema-ref-parser');
 const url = require('url');
 const deepmerge = require('deepmerge');
 const path = require('path');
+const jsonpath = require('jsonpath');
 
 const httpUtils = require('./http_utils');
 
@@ -793,6 +794,10 @@ class Template {
                         view[def] = JSON.parse(res.body);
                     } catch (e) {
                         view[def] = res.body;
+                    }
+                    if (defProp.pathQuery) {
+                        const results = jsonpath.query(view[def], defProp.pathQuery, 1);
+                        view[def] = results[0];
                     }
                     return Promise.resolve();
                 }));

--- a/lib/template.js
+++ b/lib/template.js
@@ -431,12 +431,9 @@ class Template {
     _createParametersValidator() {
         const loadSchema = (uri) => {
             uri = url.parse(uri);
-            const opts = {
-                host: uri.host,
-                port: uri.port,
-                parth: uri.pathName,
+            const opts = Object.assign({}, url.parse(uri), {
                 method: 'GET'
-            };
+            });
             return httpUtils.makeRequest(opts)
                 .then((res) => {
                     if (res.statusCode >= 400) {
@@ -771,6 +768,44 @@ class Template {
             acc = mergeStrategy(acc, curr);
             return acc;
         });
+    }
+
+    fetchHttp() {
+        const promises = [];
+        const view = {};
+        Object.entries(this.definitions).forEach(([def, defProp]) => {
+            if (!defProp.url) {
+                return;
+            }
+
+            const opts = Object.assign({}, url.parse(defProp.url), {
+                method: 'GET',
+                headers: {
+                }
+            });
+            promises.push(Promise.resolve()
+                .then(() => httpUtils.makeRequest(opts))
+                .then((res) => {
+                    if (res.statusCode >= 400) {
+                        return Promise.reject(new Error(`error loading ${defProp.url}: ${res.statusCode}`));
+                    }
+                    try {
+                        view[def] = JSON.parse(res.body);
+                    } catch (e) {
+                        view[def] = res.body;
+                    }
+                    return Promise.resolve();
+                }));
+        });
+        return Promise.all(promises)
+            .then(() => view);
+    }
+
+    fetchAndRender(parameters) {
+        return Promise.resolve()
+            .then(() => this.fetchHttp())
+            .then(httpView => Object.assign({}, parameters, httpView))
+            .then(combParams => this.render(combParams));
     }
 }
 

--- a/lib/template.js
+++ b/lib/template.js
@@ -779,11 +779,15 @@ class Template {
                 return;
             }
 
-            const opts = Object.assign({}, url.parse(defProp.url), {
+            const defaultOpts = {
                 method: 'GET',
+                host: null,
+                port: null,
                 headers: {
                 }
-            });
+            };
+            const urlOpts = (typeof defProp.url === 'string') ? url.parse(defProp.url) : defProp.url;
+            const opts = Object.assign({}, defaultOpts, urlOpts);
             promises.push(Promise.resolve()
                 .then(() => httpUtils.makeRequest(opts))
                 .then((res) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1337,8 +1337,7 @@
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "deepmerge": {
       "version": "4.2.2",
@@ -1487,7 +1486,6 @@
       "version": "1.14.3",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
       "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
-      "dev": true,
       "requires": {
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
@@ -1500,7 +1498,6 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
           "optional": true
         }
       }
@@ -1763,14 +1760,12 @@
     "estraverse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
     },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "expand-template": {
       "version": "2.0.3",
@@ -1828,8 +1823,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fastq": {
       "version": "1.8.0",
@@ -2824,6 +2818,23 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "jsonpath": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.0.2.tgz",
+      "integrity": "sha512-rmzlgFZiQPc6q4HDyK8s9Qb4oxBnI5sF61y/Co5PV0lc3q2bIuRsNdueVbhoSHdKM4fxeimphOAtfz47yjCfeA==",
+      "requires": {
+        "esprima": "1.2.2",
+        "static-eval": "2.0.2",
+        "underscore": "1.7.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
+          "integrity": "sha1-dqD9Zvz+FU/SkmZ9wmQBl1CxZXs="
+        }
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -2848,7 +2859,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
@@ -3462,7 +3472,6 @@
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
       "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-      "dev": true,
       "requires": {
         "deep-is": "~0.1.3",
         "fast-levenshtein": "~2.0.6",
@@ -3771,8 +3780,7 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -4171,6 +4179,14 @@
         "tweetnacl": "~0.14.0"
       }
     },
+    "static-eval": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
+      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
+      "requires": {
+        "escodegen": "^1.8.1"
+      }
+    },
     "stream-meter": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/stream-meter/-/stream-meter-1.0.4.tgz",
@@ -4445,7 +4461,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2"
       }
@@ -4476,6 +4491,11 @@
       "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
       "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
       "dev": true
+    },
+    "underscore": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
     },
     "unique-temp-dir": {
       "version": "1.0.0",
@@ -4597,8 +4617,7 @@
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
     },
     "wrap-ansi": {
       "version": "6.2.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "deepmerge": "^4.2.2",
     "js-yaml": "^3.14.0",
     "json-schema-merge-allof": "^0.7.0",
+    "jsonpath": "^1.0.2",
     "mustache": "^4.0.1",
     "uuid": "^7.0.3",
     "yargs": "^15.4.1"

--- a/test/template.js
+++ b/test/template.js
@@ -669,6 +669,27 @@ describe('Template class tests', function () {
                     assert.strictEqual(rendered.trim(), 'foo');
                 }));
     });
+    it('fetch_http_url_obj', function () {
+        const ymldata = `
+            definitions:
+                var:
+                    url:
+                      host: example.com
+                      path: /resource
+            template: |
+                {{var}}
+        `;
+
+        nock('http://example.com/')
+            .get('/resource')
+            .reply(200, 'foo');
+        return Template.loadYaml(ymldata)
+            .then((tmpl) => tmpl.fetchHttp())
+            .then((httpView) => {
+                console.log(JSON.stringify(httpView, null, 2));
+                assert.strictEqual(httpView.var, 'foo');
+            });
+    });
     it('fetch_http_with_data', function () {
         const ymldata = `
             definitions:

--- a/test/template.js
+++ b/test/template.js
@@ -684,7 +684,7 @@ describe('Template class tests', function () {
             .get('/resource')
             .reply(200, 'foo');
         return Template.loadYaml(ymldata)
-            .then((tmpl) => tmpl.fetchHttp())
+            .then(tmpl => tmpl.fetchHttp())
             .then((httpView) => {
                 console.log(JSON.stringify(httpView, null, 2));
                 assert.strictEqual(httpView.var, 'foo');


### PR DESCRIPTION
This PR adds a mechanism to use HTTP requests to get values from a remote resource. A new `Template.fetchHttp()` method does an HTTP request for each parameter definition that does has a `url` property and returns a parameters object with the response results. The value used from a response can be altered by specifying a JSONPath query in an optional `data` property of the parameter definition. `url` can also be an object matching Node's `http.request()` options object. Examples can be found in the newly added tests. A new convenience `Template.fetchAndRender()` will call `fetchHttp()` and pass the results to `render()`.

Items to review:
* JSON/YAML interface (`url` and `data` properties); including names
* Names of new methods:
  * `fetchHttp()`
  * `fetchAndRender()`