### PR TITLE
template: Add dataFile parameter property for including arbitrary text from files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.19.0
+## Added
+template: Add dataFile parameter property for including arbitrary text from files
+
 # v0.18.0
 ## Added
 * Add a GitHubSchemaProvider and GitHubTemplateProvider

--- a/README.md
+++ b/README.md
@@ -320,6 +320,16 @@ Parameters with a `dataFile` property:
 * have their `default` set to the contents of the file
 * given a default `format` of `hidden`
 
+Additionally, the contents of the data file can be base64 encoded before being used as for `default` by setting the `base64` property to `true`:
+
+```yaml
+definitions:
+    var:
+        dataFile: example
+        base64: true
+    template: |
+        {{var}}
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -320,16 +320,19 @@ Parameters with a `dataFile` property:
 * have their `default` set to the contents of the file
 * given a default `format` of `hidden`
 
-Additionally, the contents of the data file can be base64 encoded before being used as for `default` by setting the `base64` property to `true`:
+Additionally, the contents of the data file can be base64-encoded before being used as for `default` by setting the `toBase64` property to `true`:
 
 ```yaml
 definitions:
     var:
         dataFile: example
-        base64: true
+        toBase64: true
     template: |
         {{var}}
 ```
+
+Similarly, if the data file is base64-encoded, it can be decoded using `fromBase64`.
+If both `toBase64` and `fromBase64` are set, then `toBase64` takes precedence.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -287,6 +287,40 @@ fast.Template.loadYaml(yamldata)
     .then(template => template.forwardHttp()); // POST "foo" to http://example.com/resource
 ```
 
+### Template Data Files
+
+Sometimes it is desirable to keep a portion of a template in a separate file and include it into the template text.
+This can be done with parameters and the `dataFile` property:
+
+```javascript
+const fast = require('@f5devcentral/f5-fast-core');
+
+const templatesPath = '/path/to/templatesdir'; // directory containing example.data
+const dataProvider = new fast.FsDataProvider(templatesPath);
+const yamldata = `
+    definitions:
+        var:
+            dataFile: example
+    template: |
+        {{var}}
+`;
+
+fast.Template.loadYaml(yamldata, { dataProvider })
+    .then((template) => {
+        console.log(template.getParametersSchema());
+        console.log(template.render({virtual_port: 443});
+    });
+```
+The `FsDataProvider` will pick up on any files with the `.data` extension in the template set directory.
+When referencing the file in a template, use the filename (without the extension) as a key.
+
+Parameters with a `dataFile` property:
+
+* are removed from `required`
+* have their `default` set to the contents of the file
+* given a default `format` of `hidden`
+
+
 ## Development
 
 * To check for lint errors run `npm run lint` 

--- a/lib/data_provider.js
+++ b/lib/data_provider.js
@@ -62,12 +62,12 @@ class FsDataProvider extends BaseDataProvider {
     constructor(dataRootPath) {
         super();
 
-        this.data_path = dataRootPath;
+        this.dataPath = dataRootPath;
     }
 
     _loadData(dataName) {
         return new Promise((resolve, reject) => {
-            fs.readFile(`${this.data_path}/${dataName}.data`, (err, data) => {
+            fs.readFile(`${this.dataPath}/${dataName}.data`, (err, data) => {
                 if (err) return reject(err);
                 return resolve(data.toString('utf8'));
             });
@@ -81,7 +81,7 @@ class FsDataProvider extends BaseDataProvider {
      */
     list() {
         return new Promise((resolve, reject) => {
-            fs.readdir(this.data_path, (err, data) => {
+            fs.readdir(this.dataPath, (err, data) => {
                 if (err) return reject(err);
 
                 const list = data.filter(x => x.endsWith('.data'))

--- a/lib/data_provider.js
+++ b/lib/data_provider.js
@@ -20,20 +20,25 @@ const fs = require('fs');
 const ResourceCache = require('./resource_cache').ResourceCache;
 
 /**
- * DataProvider that fetches data from the file system
+ * Abstract base class for DataProvider classes
  */
-class FsDataProvider {
-    /**
-     * @param {string} dataRootPath - a path to a directory containing data files
-     */
-    constructor(dataRootPath) {
-        this.data_path = dataRootPath;
-        this.cache = new ResourceCache(dataName => new Promise((resolve, reject) => {
-            fs.readFile(`${dataRootPath}/${dataName}.data`, (err, data) => {
-                if (err) return reject(err);
-                return resolve(data.toString('utf8'));
-            });
-        }));
+class BaseDataProvider {
+    constructor() {
+        if (new.target === BaseDataProvider) {
+            throw new TypeError('Cannot instantiate Abstract BaseDataProvider');
+        }
+
+        const abstractMethods = [
+            '_loadData',
+            'list'
+        ];
+        abstractMethods.forEach((method) => {
+            if (this[method] === undefined) {
+                throw new TypeError(`Expected ${method} to be defined`);
+            }
+        });
+
+        this.cache = new ResourceCache(dataName => this._loadData(dataName));
     }
 
     /**
@@ -44,6 +49,29 @@ class FsDataProvider {
      */
     fetch(key) {
         return this.cache.fetch(key);
+    }
+}
+
+/**
+ * DataProvider that fetches data from the file system
+ */
+class FsDataProvider extends BaseDataProvider {
+    /**
+     * @param {string} dataRootPath - a path to a directory containing data files
+     */
+    constructor(dataRootPath) {
+        super();
+
+        this.data_path = dataRootPath;
+    }
+
+    _loadData(dataName) {
+        return new Promise((resolve, reject) => {
+            fs.readFile(`${this.data_path}/${dataName}.data`, (err, data) => {
+                if (err) return reject(err);
+                return resolve(data.toString('utf8'));
+            });
+        });
     }
 
     /**
@@ -67,41 +95,34 @@ class FsDataProvider {
 /**
  * DataProvider that fetches data from an atg-storage DataStore
  */
-class DataStoreDataProvider {
+class DataStoreDataProvider extends BaseDataProvider {
     /**
      * @param {object} datastore - an atg-storage DataStore
      * @param {string} tsName - the key to use to access the data file contents in the provided DataStore
      */
     constructor(datastore, tsName) {
+        super();
+
         this.storage = datastore;
         this.tsName = tsName;
-        this.cache = new ResourceCache(
-            dataName => this.storage.hasItem(this.tsName)
-                .then((result) => {
-                    if (result) {
-                        return Promise.resolve();
-                    }
-                    return Promise.reject(new Error(`Could not find template set "${this.tsName}" in data store`));
-                })
-                .then(() => this.storage.getItem(this.tsName))
-                .then(ts => ts.dataFiles[dataName])
-                .then((data) => {
-                    if (typeof data === 'undefined') {
-                        return Promise.reject(new Error(`Failed to find data file named "${dataName}"`));
-                    }
-                    return Promise.resolve(data);
-                })
-        );
     }
 
-    /**
-     * Get the data file contents associated with the supplied key
-     *
-     * @param {string} key
-     * @returns {object}
-     */
-    fetch(key) {
-        return this.cache.fetch(key);
+    _loadData(dataName) {
+        return this.storage.hasItem(this.tsName)
+            .then((result) => {
+                if (result) {
+                    return Promise.resolve();
+                }
+                return Promise.reject(new Error(`Could not find template set "${this.tsName}" in data store`));
+            })
+            .then(() => this.storage.getItem(this.tsName))
+            .then(ts => ts.dataFiles[dataName])
+            .then((data) => {
+                if (typeof data === 'undefined') {
+                    return Promise.reject(new Error(`Failed to find data file named "${dataName}"`));
+                }
+                return Promise.resolve(data);
+            });
     }
 
     /**
@@ -123,6 +144,7 @@ class DataStoreDataProvider {
 }
 
 module.exports = {
+    BaseDataProvider,
     FsDataProvider,
     DataStoreDataProvider
 };

--- a/lib/data_provider.js
+++ b/lib/data_provider.js
@@ -1,0 +1,128 @@
+/* Copyright 2021 F5 Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const fs = require('fs');
+
+const ResourceCache = require('./resource_cache').ResourceCache;
+
+/**
+ * DataProvider that fetches data from the file system
+ */
+class FsDataProvider {
+    /**
+     * @param {string} dataRootPath - a path to a directory containing data files
+     */
+    constructor(dataRootPath) {
+        this.data_path = dataRootPath;
+        this.cache = new ResourceCache(dataName => new Promise((resolve, reject) => {
+            fs.readFile(`${dataRootPath}/${dataName}.data`, (err, data) => {
+                if (err) return reject(err);
+                return resolve(data.toString('utf8'));
+            });
+        }));
+    }
+
+    /**
+     * Get the data file contents associated with the supplied key
+     *
+     * @param {string} key
+     * @returns {object}
+     */
+    fetch(key) {
+        return this.cache.fetch(key);
+    }
+
+    /**
+     * List all data files known to the provider
+     *
+     * @returns {string[]}
+     */
+    list() {
+        return new Promise((resolve, reject) => {
+            fs.readdir(this.data_path, (err, data) => {
+                if (err) return reject(err);
+
+                const list = data.filter(x => x.endsWith('.data'))
+                    .map(x => x.replace(/.data$/, ''));
+                return resolve(list);
+            });
+        });
+    }
+}
+
+/**
+ * DataProvider that fetches data from an atg-storage DataStore
+ */
+class DataStoreDataProvider {
+    /**
+     * @param {object} datastore - an atg-storage DataStore
+     * @param {string} tsName - the key to use to access the data file contents in the provided DataStore
+     */
+    constructor(datastore, tsName) {
+        this.storage = datastore;
+        this.tsName = tsName;
+        this.cache = new ResourceCache(
+            dataName => this.storage.hasItem(this.tsName)
+                .then((result) => {
+                    if (result) {
+                        return Promise.resolve();
+                    }
+                    return Promise.reject(new Error(`Could not find template set "${this.tsName}" in data store`));
+                })
+                .then(() => this.storage.getItem(this.tsName))
+                .then(ts => ts.dataFiles[dataName])
+                .then((data) => {
+                    if (typeof data === 'undefined') {
+                        return Promise.reject(new Error(`Failed to find data file named "${dataName}"`));
+                    }
+                    return Promise.resolve(data);
+                })
+        );
+    }
+
+    /**
+     * Get the data file contents associated with the supplied key
+     *
+     * @param {string} key
+     * @returns {object}
+     */
+    fetch(key) {
+        return this.cache.fetch(key);
+    }
+
+    /**
+     * List all data files known to the provider
+     *
+     * @returns {string[]}
+     */
+    list() {
+        return this.storage.hasItem(this.tsName)
+            .then((result) => {
+                if (result) {
+                    return Promise.resolve();
+                }
+                return Promise.reject(new Error(`Could not find template set "${this.tsName}" in data store`));
+            })
+            .then(() => this.storage.getItem(this.tsName))
+            .then(ts => Object.keys(ts.dataFiles));
+    }
+}
+
+module.exports = {
+    FsDataProvider,
+    DataStoreDataProvider
+};

--- a/lib/github_provider.js
+++ b/lib/github_provider.js
@@ -113,6 +113,48 @@ class GitHubSchemaProvider {
 }
 
 /**
+ * DataProvider that fetches data from a GitHub repository
+ */
+class GitHubDataProvider {
+    /**
+     * @param {string} dataRootPath - a path to a directory containing data files
+     */
+    constructor(repo, dataRootPath, options) {
+        options = options || {};
+
+        this._rootDir = `/${dataRootPath}`;
+        this._contentsApi = new GitHubContentsApi(repo, {
+            apiToken: options.apiToken
+        });
+        this.cache = new ResourceCache(dataName => Promise.resolve()
+            .then(() => this._contentsApi.getContentsData(`${this._rootDir}/${dataName}.data`)));
+    }
+
+    /**
+     * Get the data file contents associated with the supplied key
+     *
+     * @param {string} key
+     * @returns {object}
+     */
+    fetch(key) {
+        return this.cache.fetch(key);
+    }
+
+    /**
+     * List all data files known to the provider
+     *
+     * @returns {string[]}
+     */
+    list() {
+        return Promise.resolve()
+            .then(() => this._contentsApi.getContentsByType(this._rootDir, 'file'))
+            .then(files => files
+                .filter(x => x.endsWith('.data'))
+                .map(x => stripExtension(x)));
+    }
+}
+
+/**
  * TemplateProvider that fetches data from a GitHub repository
  */
 class GitHubTemplateProvider extends BaseTemplateProvider {
@@ -127,6 +169,7 @@ class GitHubTemplateProvider extends BaseTemplateProvider {
         this._apiToken = options.apiToken;
 
         this._schemaProviders = {};
+        this._dataProviders = {};
 
         this._contentsApi = new GitHubContentsApi(this.repo, {
             apiToken: this._apiToken
@@ -139,6 +182,7 @@ class GitHubTemplateProvider extends BaseTemplateProvider {
         const tmplName = tmplParts[tmplParts.length - 1];
 
         const schemaProvider = this._getSchemaProvider(tmplDir);
+        const dataProvider = this._getDataProvider(tmplDir);
         return Promise.resolve()
             .then(() => this._contentsApi.getContentsByType(tmplDir, 'file'))
             .then((files) => {
@@ -162,6 +206,7 @@ class GitHubTemplateProvider extends BaseTemplateProvider {
                     .then(() => this._contentsApi.getContentsData(fname))
                     .then(tmpldata => Template[useMst ? 'loadMst' : 'loadYaml'](tmpldata, {
                         schemaProvider,
+                        dataProvider,
                         templateProvider: this
                     }));
             });
@@ -173,6 +218,14 @@ class GitHubTemplateProvider extends BaseTemplateProvider {
         }
 
         return this._schemaProviders[tsName];
+    }
+
+    _getDataProvider(tsName) {
+        if (!this._dataProviders[tsName]) {
+            this._dataProviders[tsName] = new GitHubDataProvider(this.repo, tsName, { apiToken: this._apiToken });
+        }
+
+        return this._dataProviders[tsName];
     }
 
     /**
@@ -249,6 +302,35 @@ class GitHubTemplateProvider extends BaseTemplateProvider {
                     )))
             )))
             .then(() => schemas);
+    }
+
+    /**
+     * Get all data files known to the provider (optionally filtered by the supplied set name)
+     *
+     * @param {string} [filteredSetName] - only return data for this template set (instead of all template sets)
+     * @returns {Promise} Promise resolves to an object containing data files
+     */
+    getDataFiles(filteredSetName) {
+        const dataFiles = {};
+        return Promise.resolve()
+            .then(() => (filteredSetName ? [filteredSetName] : this.listSets()))
+            .then(setList => Promise.all(setList.map(
+                tsName => this._getDataProvider(tsName).list()
+                    .then(dataFileList => Promise.all(dataFileList.map(
+                        dataName => this._getDataProvider(tsName).fetch(dataName)
+                            .then((data) => {
+                                const name = `${tsName}/${dataName}`;
+                                const dataHash = crypto.createHash('sha256');
+                                dataHash.update(data);
+                                dataFiles[name] = {
+                                    name,
+                                    data,
+                                    hash: dataHash.digest('hex')
+                                };
+                            })
+                    )))
+            )))
+            .then(() => dataFiles);
     }
 }
 

--- a/lib/github_provider.js
+++ b/lib/github_provider.js
@@ -22,6 +22,7 @@ const axios = require('axios');
 const ResourceCache = require('./resource_cache').ResourceCache;
 const Template = require('./template').Template;
 const { BaseTemplateProvider } = require('./template_provider');
+const { BaseDataProvider } = require('./data_provider');
 const { stripExtension } = require('./utils');
 
 class GitHubContentsApi {
@@ -115,29 +116,23 @@ class GitHubSchemaProvider {
 /**
  * DataProvider that fetches data from a GitHub repository
  */
-class GitHubDataProvider {
+class GitHubDataProvider extends BaseDataProvider {
     /**
      * @param {string} dataRootPath - a path to a directory containing data files
      */
     constructor(repo, dataRootPath, options) {
+        super();
         options = options || {};
 
         this._rootDir = `/${dataRootPath}`;
         this._contentsApi = new GitHubContentsApi(repo, {
             apiToken: options.apiToken
         });
-        this.cache = new ResourceCache(dataName => Promise.resolve()
-            .then(() => this._contentsApi.getContentsData(`${this._rootDir}/${dataName}.data`)));
     }
 
-    /**
-     * Get the data file contents associated with the supplied key
-     *
-     * @param {string} key
-     * @returns {object}
-     */
-    fetch(key) {
-        return this.cache.fetch(key);
+    _loadData(dataName) {
+        return Promise.resolve()
+            .then(() => this._contentsApi.getContentsData(`${this._rootDir}/${dataName}.data`));
     }
 
     /**

--- a/lib/github_provider.js
+++ b/lib/github_provider.js
@@ -19,10 +19,10 @@ const crypto = require('crypto');
 
 const axios = require('axios');
 
-const ResourceCache = require('./resource_cache').ResourceCache;
 const Template = require('./template').Template;
-const { BaseTemplateProvider } = require('./template_provider');
+const { BaseSchemaProvider } = require('./schema_provider');
 const { BaseDataProvider } = require('./data_provider');
+const { BaseTemplateProvider } = require('./template_provider');
 const { stripExtension } = require('./utils');
 
 class GitHubContentsApi {
@@ -76,27 +76,21 @@ class GitHubContentsApi {
 /**
  * SchemaProvider that fetches data from a GitHub repository
  */
-class GitHubSchemaProvider {
+class GitHubSchemaProvider extends BaseSchemaProvider {
     constructor(repo, schemaRootPath, options) {
+        super();
+
         options = options || {};
 
         this._rootDir = `/${schemaRootPath}`;
         this._contentsApi = new GitHubContentsApi(repo, {
             apiToken: options.apiToken
         });
-
-        this.cache = new ResourceCache(schemaName => Promise.resolve()
-            .then(() => this._contentsApi.getContentsData(`${this._rootDir}/${schemaName}.json`)));
     }
 
-    /**
-     * Get the schema associated with the supplied key
-     *
-     * @param {string} key
-     * @returns {object}
-     */
-    fetch(key) {
-        return this.cache.fetch(key);
+    _loadSchema(schemaName) {
+        return Promise.resolve()
+            .then(() => this._contentsApi.getContentsData(`${this._rootDir}/${schemaName}.json`));
     }
 
     /**

--- a/lib/schema_provider.js
+++ b/lib/schema_provider.js
@@ -62,12 +62,20 @@ class FsSchemaProvider extends BaseSchemaProvider {
     constructor(schemaRootPath) {
         super();
 
-        this.schema_path = schemaRootPath;
+        this.schemaPath = schemaRootPath;
+    }
+
+    get schema_path() {
+        return this.schemaPath;
+    }
+
+    set schema_path(value) {
+        this.schemaPath = value;
     }
 
     _loadSchema(schemaName) {
         return new Promise((resolve, reject) => {
-            fs.readFile(`${this.schema_path}/${schemaName}.json`, (err, data) => {
+            fs.readFile(`${this.schemaPath}/${schemaName}.json`, (err, data) => {
                 if (err) return reject(err);
                 return resolve(data.toString('utf8'));
             });
@@ -81,7 +89,7 @@ class FsSchemaProvider extends BaseSchemaProvider {
      */
     list() {
         return new Promise((resolve, reject) => {
-            fs.readdir(this.schema_path, (err, data) => {
+            fs.readdir(this.schemaPath, (err, data) => {
                 if (err) return reject(err);
 
                 const list = data.filter(x => x.endsWith('.json'))

--- a/lib/schema_provider.js
+++ b/lib/schema_provider.js
@@ -20,20 +20,25 @@ const fs = require('fs');
 const ResourceCache = require('./resource_cache').ResourceCache;
 
 /**
- * SchemaProvider that fetches data from the file system
+ * Abstract base class for SchemaProvider classes
  */
-class FsSchemaProvider {
-    /**
-     * @param {string} schemaRootPath - a path to a directory containing schema files
-     */
-    constructor(schemaRootPath) {
-        this.schema_path = schemaRootPath;
-        this.cache = new ResourceCache(schemaName => new Promise((resolve, reject) => {
-            fs.readFile(`${schemaRootPath}/${schemaName}.json`, (err, data) => {
-                if (err) return reject(err);
-                return resolve(data.toString('utf8'));
-            });
-        }));
+class BaseSchemaProvider {
+    constructor() {
+        if (new.target === BaseSchemaProvider) {
+            throw new TypeError('Cannot instantiate Abstract BaseSchemaProvider');
+        }
+
+        const abstractMethods = [
+            '_loadSchema',
+            'list'
+        ];
+        abstractMethods.forEach((method) => {
+            if (this[method] === undefined) {
+                throw new TypeError(`Expected ${method} to be defined`);
+            }
+        });
+
+        this.cache = new ResourceCache(schemaName => this._loadSchema(schemaName));
     }
 
     /**
@@ -44,6 +49,29 @@ class FsSchemaProvider {
      */
     fetch(key) {
         return this.cache.fetch(key);
+    }
+}
+
+/**
+ * SchemaProvider that fetches data from the file system
+ */
+class FsSchemaProvider extends BaseSchemaProvider {
+    /**
+     * @param {string} schemaRootPath - a path to a directory containing schema files
+     */
+    constructor(schemaRootPath) {
+        super();
+
+        this.schema_path = schemaRootPath;
+    }
+
+    _loadSchema(schemaName) {
+        return new Promise((resolve, reject) => {
+            fs.readFile(`${this.schema_path}/${schemaName}.json`, (err, data) => {
+                if (err) return reject(err);
+                return resolve(data.toString('utf8'));
+            });
+        });
     }
 
     /**
@@ -67,41 +95,34 @@ class FsSchemaProvider {
 /**
  * SchemaProvider that fetches data from an atg-storage DataStore
  */
-class DataStoreSchemaProvider {
+class DataStoreSchemaProvider extends BaseSchemaProvider {
     /**
      * @param {object} datastore - an atg-storage DataStore
      * @param {string} tsName - the key to use to access the schema in the provided DataStore
      */
     constructor(datastore, tsName) {
+        super();
+
         this.storage = datastore;
         this.tsName = tsName;
-        this.cache = new ResourceCache(
-            schemaName => this.storage.hasItem(this.tsName)
-                .then((result) => {
-                    if (result) {
-                        return Promise.resolve();
-                    }
-                    return Promise.reject(new Error(`Could not find template set "${this.tsName}" in data store`));
-                })
-                .then(() => this.storage.getItem(this.tsName))
-                .then(ts => ts.schemas[schemaName])
-                .then((schema) => {
-                    if (typeof schema === 'undefined') {
-                        return Promise.reject(new Error(`Failed to find schema named "${schemaName}"`));
-                    }
-                    return Promise.resolve(schema);
-                })
-        );
     }
 
-    /**
-     * Get the schema associated with the supplied key
-     *
-     * @param {string} key
-     * @returns {object}
-     */
-    fetch(key) {
-        return this.cache.fetch(key);
+    _loadSchema(schemaName) {
+        return this.storage.hasItem(this.tsName)
+            .then((result) => {
+                if (result) {
+                    return Promise.resolve();
+                }
+                return Promise.reject(new Error(`Could not find template set "${this.tsName}" in data store`));
+            })
+            .then(() => this.storage.getItem(this.tsName))
+            .then(ts => ts.schemas[schemaName])
+            .then((schema) => {
+                if (typeof schema === 'undefined') {
+                    return Promise.reject(new Error(`Failed to find schema named "${schemaName}"`));
+                }
+                return Promise.resolve(schema);
+            });
     }
 
     /**
@@ -123,6 +144,7 @@ class DataStoreSchemaProvider {
 }
 
 module.exports = {
+    BaseSchemaProvider,
     FsSchemaProvider,
     DataStoreSchemaProvider
 };

--- a/lib/template.js
+++ b/lib/template.js
@@ -259,6 +259,22 @@ class Template {
             }, {}));
     }
 
+    _loadDataFiles(dataProvider) {
+        if (!dataProvider) {
+            return Promise.resolve({});
+        }
+
+        return dataProvider.list()
+            .then(dataList => Promise.all(
+                dataList.map(x => Promise.all([Promise.resolve(x), dataProvider.fetch(x)]))
+            ))
+            .then(dataFiles => dataFiles.reduce((acc, curr) => {
+                const [dataName, data] = curr;
+                acc[dataName] = data;
+                return acc;
+            }, {}));
+    }
+
     _descriptionFromTemplate() {
         const tokens = Mustache.parse(this.templateText);
         const comments = tokens.filter(x => x[0] === '!');
@@ -297,11 +313,12 @@ class Template {
             propDef.format !== 'hidden'
             && propDef.format !== 'info'
             && !propDef.mathExpression
+            && !propDef.dataFile
             && typeof propDef.default === 'undefined'
         );
     }
 
-    _handleParsed(parsed, typeSchemas) {
+    _handleParsed(parsed, typeSchemas, dataFiles) {
         const primitives = {
             boolean: false,
             object: {},
@@ -388,6 +405,14 @@ class Template {
                         }
                     });
                 }
+
+                if (propDef.dataFile) {
+                    if (!propDef.format) {
+                        propDef.format = 'hidden';
+                    }
+                    propDef.default = dataFiles[propDef.dataFile];
+                    delete propDef.dataFile;
+                }
                 break;
             }
             case '>': {
@@ -402,7 +427,7 @@ class Template {
                 break;
             }
             case '#': {
-                const items = this._handleParsed(curr[4], typeSchemas);
+                const items = this._handleParsed(curr[4], typeSchemas, dataFiles);
                 const schemaDef = deepmerge(
                     this._typeDefinitions[type] || {},
                     this.definitions[defName] || {}
@@ -477,7 +502,7 @@ class Template {
                 break;
             }
             case '^': {
-                const items = this._handleParsed(curr[4], typeSchemas);
+                const items = this._handleParsed(curr[4], typeSchemas, dataFiles);
                 const schemaDef = Object.assign(
                     this._typeDefinitions[type] || {},
                     this.definitions[defName] || {}
@@ -582,7 +607,7 @@ class Template {
         return schema;
     }
 
-    _parametersSchemaFromTemplate(typeSchemas) {
+    _parametersSchemaFromTemplate(typeSchemas, dataFiles) {
         const mergedDefs = [];
         ['oneOf', 'allOf', 'anyOf'].forEach((xOf) => {
             this[`_${xOf}`].forEach((tmpl) => {
@@ -601,7 +626,7 @@ class Template {
         });
         Object.entries(this.definitions).forEach(([name, def]) => {
             if (def.template) {
-                const newDef = this._handleParsed(Mustache.parse(def.template), typeSchemas);
+                const newDef = this._handleParsed(Mustache.parse(def.template), typeSchemas, dataFiles);
                 delete newDef.template;
                 this._typeDefinitions[name] = newDef;
                 this._partials[name] = this._cleanTemplateText(def.template);
@@ -609,7 +634,7 @@ class Template {
                 this._typeDefinitions[name] = JSON.parse(JSON.stringify(def));
             }
         });
-        this._parametersSchema = this._handleParsed(Mustache.parse(this.templateText), typeSchemas);
+        this._parametersSchema = this._handleParsed(Mustache.parse(this.templateText), typeSchemas, dataFiles);
 
         // If we just ended up with an empty string type, then we have no types and we
         // should return an empty object instead.
@@ -704,10 +729,11 @@ class Template {
      *
      * @param {string} msttext - Mustache text to parse and create a `Template` from
      * @param {SchemaProvider} [schemaProvider] - SchemaProvider to use to fetch schema referenced by the template
+     * @param {DataProvider} [dataProvider] - DataProvider to use to fetch data files referenced by the template
      *
      * @returns {Promise} Promise resolves to `Template`
      */
-    static loadMst(msttext, schemaProvider) {
+    static loadMst(msttext, schemaProvider, dataProvider) {
         if (schemaProvider && schemaProvider.schemaProvider) {
             schemaProvider = schemaProvider.schemaProvider;
         }
@@ -715,10 +741,13 @@ class Template {
         const tmpl = new this();
         tmpl._recordSource('MST', msttext);
         tmpl.templateText = msttext;
-        return tmpl._loadTypeSchemas(schemaProvider)
-            .then((typeSchemas) => {
+        return Promise.all([
+            tmpl._loadTypeSchemas(schemaProvider),
+            tmpl._loadDataFiles(dataProvider)
+        ])
+            .then(([typeSchemas, dataFiles]) => {
                 tmpl._descriptionFromTemplate();
-                tmpl._parametersSchemaFromTemplate(typeSchemas);
+                tmpl._parametersSchemaFromTemplate(typeSchemas, dataFiles);
             })
             .then(() => tmpl._createParametersValidator())
             .then(() => tmpl);
@@ -743,6 +772,7 @@ class Template {
     static loadYaml(yamltext, options) {
         let schemaProvider;
         let templateProvider;
+        let dataProvider;
         let filePath;
         let rootDir;
         let skipValidation;
@@ -757,6 +787,7 @@ class Template {
         } else if (options) {
             schemaProvider = options.schemaProvider;
             templateProvider = options.templateProvider;
+            dataProvider = options.dataProvider;
             filePath = options.filePath;
             rootDir = options.rootDir;
             skipValidation = options.skipValidation;
@@ -853,9 +884,12 @@ class Template {
             .then((tmplList) => {
                 tmpl._anyOf = tmplList;
             })
-            .then(() => tmpl._loadTypeSchemas(schemaProvider))
-            .then((typeSchemas) => {
-                tmpl._parametersSchemaFromTemplate(typeSchemas);
+            .then(() => Promise.all([
+                tmpl._loadTypeSchemas(schemaProvider),
+                tmpl._loadDataFiles(dataProvider)
+            ]))
+            .then(([typeSchemas, dataFiles]) => {
+                tmpl._parametersSchemaFromTemplate(typeSchemas, dataFiles);
             })
             .then(() => {
                 if (skipValidation) {

--- a/lib/template.js
+++ b/lib/template.js
@@ -412,8 +412,10 @@ class Template {
                     }
 
                     const dataFile = dataFiles[propDef.dataFile];
-                    if (propDef.base64) {
+                    if (propDef.toBase64) {
                         propDef.default = Buffer.from(dataFile, 'utf8').toString('base64');
+                    } else if (propDef.fromBase64) {
+                        propDef.default = Buffer.from(dataFile, 'base64').toString('utf8');
                     } else {
                         propDef.default = dataFile;
                     }

--- a/lib/template.js
+++ b/lib/template.js
@@ -410,7 +410,13 @@ class Template {
                     if (!propDef.format) {
                         propDef.format = 'hidden';
                     }
-                    propDef.default = dataFiles[propDef.dataFile];
+
+                    const dataFile = dataFiles[propDef.dataFile];
+                    if (propDef.base64) {
+                        propDef.default = Buffer.from(dataFile, 'utf8').toString('base64');
+                    } else {
+                        propDef.default = dataFile;
+                    }
                     delete propDef.dataFile;
                 }
                 break;

--- a/lib/template_provider.js
+++ b/lib/template_provider.js
@@ -24,6 +24,7 @@ const ResourceCache = require('./resource_cache').ResourceCache;
 const Template = require('./template').Template;
 const { FsSchemaProvider } = require('./schema_provider');
 const { stripExtension } = require('./utils');
+const { FsDataProvider } = require('./data_provider');
 
 /**
  * Abstract base class for TemplateProvider classes
@@ -42,7 +43,8 @@ class BaseTemplateProvider {
             'listSets',
             'removeSet',
             'list',
-            'getSchemas'
+            'getSchemas',
+            'getDataFiles'
         ];
         abstractMethods.forEach((method) => {
             if (this[method] === undefined) {
@@ -146,9 +148,10 @@ class BaseTemplateProvider {
     getSetData(setName) {
         return Promise.all([
             this.fetchSet(setName),
-            this.getSchemas(setName)
+            this.getSchemas(setName),
+            this.getDataFiles(setName)
         ])
-            .then(([templates, schemas]) => {
+            .then(([templates, schemas, dataFiles]) => {
                 const tsHash = crypto.createHash('sha256');
                 const tmplHashes = Object.values(templates).map(x => x.sourceHash).sort();
                 tmplHashes.forEach((hash) => {
@@ -156,6 +159,10 @@ class BaseTemplateProvider {
                 });
                 const schemaHashes = Object.values(schemas).map(x => x.hash).sort();
                 schemaHashes.forEach((hash) => {
+                    tsHash.update(hash);
+                });
+                const dataHashes = Object.values(dataFiles).map(x => x.hash).sort();
+                dataHashes.forEach((hash) => {
                     tsHash.update(hash);
                 });
 
@@ -183,6 +190,14 @@ class BaseTemplateProvider {
                         acc.push({
                             name: schema.name,
                             hash: schema.hash
+                        });
+                        return acc;
+                    }, []),
+                    dataFiles: Object.keys(dataFiles).reduce((acc, curr) => {
+                        const data = dataFiles[curr];
+                        acc.push({
+                            name: data.name,
+                            hash: data.hash
                         });
                         return acc;
                     }, [])
@@ -216,13 +231,16 @@ class FsTemplateProvider extends BaseTemplateProvider {
         super(supportedHashes);
         this.config_template_path = templateRootPath;
         this.schemaProviders = {};
+        this.dataProviders = {};
         this.filteredSets = new Set(filteredSets || []);
     }
 
     _loadTemplate(templateName) {
         const tsName = templateName.split('/')[0];
         this._ensureSchemaProvider(tsName);
+        this._ensureDataProvider(tsName);
         const schemaProvider = this.schemaProviders[tsName];
+        const dataProvider = this.dataProviders[tsName];
         let useMst = 0;
         let tmplpath = `${this.config_template_path}/${templateName}`;
         if (fs.existsSync(`${tmplpath}.yml`)) {
@@ -246,6 +264,7 @@ class FsTemplateProvider extends BaseTemplateProvider {
         })
             .then(tmpldata => Template[(useMst) ? 'loadMst' : 'loadYaml'](tmpldata, {
                 schemaProvider,
+                dataProvider,
                 templateProvider: this,
                 rootDir: path.resolve(this.config_template_path, tsName)
             }));
@@ -254,6 +273,15 @@ class FsTemplateProvider extends BaseTemplateProvider {
     _ensureSchemaProvider(tsName) {
         if (!this.schemaProviders[tsName]) {
             this.schemaProviders[tsName] = new FsSchemaProvider(path.resolve(
+                this.config_template_path,
+                tsName
+            ));
+        }
+    }
+
+    _ensureDataProvider(tsName) {
+        if (!this.dataProviders[tsName]) {
+            this.dataProviders[tsName] = new FsDataProvider(path.resolve(
                 this.config_template_path,
                 tsName
             ));
@@ -342,6 +370,44 @@ class FsTemplateProvider extends BaseTemplateProvider {
                     )))
             )))
             .then(() => schemas);
+    }
+
+    /**
+     * Get all data files known to the provider (optionally filtered by the supplied set name)
+     *
+     * @param {string} [filteredSetName] - only return data for this template set (instead of all template sets)
+     * @returns {Promise} Promise resolves to an object containing data files
+     */
+    getDataFiles(filteredSetName) {
+        const dataFiles = {};
+        return Promise.resolve()
+            .then(() => {
+                if (filteredSetName) {
+                    return Promise.resolve([filteredSetName]);
+                }
+                return this.listSets();
+            })
+            .then((setList) => {
+                setList.forEach(tsName => this._ensureDataProvider(tsName));
+                return setList;
+            })
+            .then(setList => Promise.all(setList.map(
+                tsName => this.dataProviders[tsName].list()
+                    .then(dataList => Promise.all(dataList.map(
+                        dataName => this.dataProviders[tsName].fetch(dataName)
+                            .then((data) => {
+                                const name = `${tsName}/${dataName}`;
+                                const dataHash = crypto.createHash('sha256');
+                                dataHash.update(data);
+                                dataFiles[name] = {
+                                    name,
+                                    data,
+                                    hash: dataHash.digest('hex')
+                                };
+                            })
+                    )))
+            )))
+            .then(() => dataFiles);
     }
 
     /**
@@ -523,6 +589,39 @@ class DataStoreTemplateProvider extends BaseTemplateProvider {
     }
 
     /**
+     * Get all data files known to the provider (optionally filtered by the supplied set name)
+     *
+     * @param {string} [filteredSetName] - only return data for this template set (instead of all template sets)
+     * @returns {Promise} Promise resolves to an object containing data files
+     */
+    getDataFiles(filteredSetName) {
+        return Promise.resolve()
+            .then(() => {
+                if (filteredSetName) {
+                    return Promise.resolve([filteredSetName]);
+                }
+                return this.listSets();
+            })
+            .then(setNames => Promise.all(setNames.map(x => this.storage.getItem(x))))
+            .then(setData => setData.filter(x => x))
+            .then(setData => setData.reduce((acc, curr) => {
+                const tsName = curr.name;
+                Object.keys(curr.dataFiles || []).forEach((dataName) => {
+                    const dataFile = curr.dataFiles[dataName];
+                    const name = `${tsName}/${dataName}`;
+                    const dataHash = crypto.createHash('sha256');
+                    dataHash.update(dataFile);
+                    acc[name] = {
+                        name,
+                        data: dataFile,
+                        hash: dataHash.digest('hex')
+                    };
+                });
+                return acc;
+            }, {}));
+    }
+
+    /**
      * Create a new DataStoreTemplateProvider by searching the file system for template sets
      *
      * @param {object} datastore - an atg-storage DataStore
@@ -538,9 +637,10 @@ class DataStoreTemplateProvider extends BaseTemplateProvider {
             .then(() => fsprovider.listSets())
             .then(setList => Promise.all(setList.map(tsName => Promise.all([
                 fsprovider.fetchSet(tsName),
-                fsprovider.getSchemas(tsName)
+                fsprovider.getSchemas(tsName),
+                fsprovider.getDataFiles(tsName)
             ])
-                .then(([setTemplates, setSchemas]) => {
+                .then(([setTemplates, setSchemas, setDataFiles]) => {
                     const templates = Object.entries(setTemplates).reduce((acc, curr) => {
                         const [tmplPath, tmplData] = curr;
                         const tmplName = tmplPath.split('/')[1];
@@ -553,11 +653,18 @@ class DataStoreTemplateProvider extends BaseTemplateProvider {
                         acc[schemaName] = schemaData.data;
                         return acc;
                     }, {});
+                    const dataFiles = Object.entries(setDataFiles).reduce((acc, curr) => {
+                        const [dataPath, data] = curr;
+                        const dataName = dataPath.split('/')[1];
+                        acc[dataName] = data.data;
+                        return acc;
+                    }, {});
 
                     const tsData = {
                         name: tsName,
                         templates,
-                        schemas
+                        schemas,
+                        dataFiles
                     };
 
                     // DataStores do not guarantee support for parallel writes
@@ -568,6 +675,7 @@ class DataStoreTemplateProvider extends BaseTemplateProvider {
                         name: tsName,
                         templates: {},
                         schemas: {},
+                        dataFiles: {},
                         error: e.message
                     };
 

--- a/test/data_provider.js
+++ b/test/data_provider.js
@@ -1,0 +1,91 @@
+/* Copyright 2021 F5 Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable prefer-arrow-callback */
+/* eslint-disable func-names */
+/* eslint-disable no-console */
+
+'use strict';
+
+const fs = require('fs');
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+
+chai.use(chaiAsPromised);
+const assert = chai.assert;
+
+const StorageMemory = require('@f5devcentral/atg-storage').StorageMemory;
+const { FsDataProvider, DataStoreDataProvider } = require('../lib/data_provider');
+
+const datasPath = './test/templatesets/test/';
+
+function runSharedTests(createProvider) {
+    it('construct', function () {
+        const provider = createProvider();
+        assert.ok(provider);
+    });
+    it('load_single', function () {
+        const provider = createProvider();
+        return provider.fetch('textData.txt')
+            .then((data) => {
+                assert.strictEqual(data, 'Lorem ipsum\n');
+            });
+    });
+    it('load_single_bad', function () {
+        const provider = createProvider();
+        return assert.isRejected(provider.fetch('does_not_exist'));
+    });
+    it('load_list', function () {
+        const provider = createProvider();
+        return assert.becomes(provider.list(), [
+            'textData.txt'
+        ]);
+    });
+}
+
+describe('data provider tests', function () {
+    describe('FsDataProvider', function () {
+        runSharedTests(() => new FsDataProvider(datasPath));
+        it('bad_data_path', function () {
+            const provider = new FsDataProvider('bad/path');
+            return Promise.all([
+                assert.isRejected(provider.list()),
+                assert.isRejected(provider.fetch('f5'))
+            ]);
+        });
+    });
+
+    describe('DataStoreDataProvider', function () {
+        const createDataStore = () => new StorageMemory({
+            test: {
+                templates: {},
+                dataFiles: fs.readdirSync(`${datasPath}`).filter(x => x.endsWith('.data')).reduce(
+                    (acc, fname) => {
+                        acc[fname.replace(/.data$/, '')] = fs.readFileSync(`${datasPath}/${fname}`, { encoding: 'utf8' });
+                        return acc;
+                    }, {}
+                )
+            }
+        });
+        runSharedTests(() => new DataStoreDataProvider(createDataStore(), 'test'));
+        it('bad_ts_name', function () {
+            const provider = new DataStoreDataProvider(createDataStore(), 'does_not_exist');
+            return Promise.all([
+                assert.isRejected(provider.list()),
+                assert.isRejected(provider.fetch('textData'))
+            ]);
+        });
+    });
+});

--- a/test/schema_provider.js
+++ b/test/schema_provider.js
@@ -71,6 +71,13 @@ describe('schema provider tests', function () {
                 assert.isRejected(provider.fetch('f5'))
             ]);
         });
+
+        it('schema_path_alias', function () {
+            const provider = new FsSchemaProvider(schemasPath);
+
+            provider.schema_path = 'foo';
+            assert.strictEqual(provider.schemaPath, provider.schema_path);
+        });
     });
 
     describe('DataStoreSchemaProvider', function () {

--- a/test/template.js
+++ b/test/template.js
@@ -1259,12 +1259,21 @@ describe('Template class tests', function () {
                     dataFile: textData.txt
                 base64:
                     dataFile: textData.txt
-                    base64: true
+                    toBase64: true
+                decoded:
+                    dataFile: textData.txt
+                    fromBase64: true
+                toAndFrom:
+                    dataFile: textData.txt
+                    toBase64: true
+                    fromBase64: true
             template: |-
                 {{fromFile}}
                 {{base64}}
+                {{decoded}}
+                {{toAndFrom}}
         `;
-        const reference = 'Lorem ipsum\n\nTG9yZW0gaXBzdW0K';
+        const reference = 'Lorem ipsum\n\nTG9yZW0gaXBzdW0K\n.�ޚ*l�\nTG9yZW0gaXBzdW0K';
         return Template.loadYaml(yamldata, { dataProvider })
             .then((tmpl) => {
                 const schema = tmpl.getParametersSchema();
@@ -1277,6 +1286,8 @@ describe('Template class tests', function () {
                 assert.strictEqual(fileProp.default, 'Lorem ipsum\n');
 
                 assert.strictEqual(schema.properties.base64.default, 'TG9yZW0gaXBzdW0K');
+                assert.strictEqual(schema.properties.decoded.default, '.�ޚ*l�');
+                assert.strictEqual(schema.properties.toAndFrom.default, 'TG9yZW0gaXBzdW0K');
 
                 const rendered = tmpl.render();
                 console.log(rendered);

--- a/test/template.js
+++ b/test/template.js
@@ -1257,10 +1257,14 @@ describe('Template class tests', function () {
             definitions:
                 fromFile:
                     dataFile: textData.txt
+                base64:
+                    dataFile: textData.txt
+                    base64: true
             template: |-
                 {{fromFile}}
+                {{base64}}
         `;
-        const reference = 'Lorem ipsum\n';
+        const reference = 'Lorem ipsum\n\nTG9yZW0gaXBzdW0K';
         return Template.loadYaml(yamldata, { dataProvider })
             .then((tmpl) => {
                 const schema = tmpl.getParametersSchema();
@@ -1271,6 +1275,8 @@ describe('Template class tests', function () {
                 assert(!schema.required.includes('fromFile'), 'definition with "file" property should not be required');
                 assert.strictEqual(fileProp.format, 'hidden');
                 assert.strictEqual(fileProp.default, 'Lorem ipsum\n');
+
+                assert.strictEqual(schema.properties.base64.default, 'TG9yZW0gaXBzdW0K');
 
                 const rendered = tmpl.render();
                 console.log(rendered);

--- a/test/template_provider.js
+++ b/test/template_provider.js
@@ -78,6 +78,7 @@ function runSharedTests(createProvider) {
                 assert.strictEqual(schema.description, '');
                 assert.strictEqual(tmpl.target, 'as3');
                 assert.ok(tmpl._partials.chatlog);
+                assert.strictEqual(schema.properties.fromFile.default, 'Lorem ipsum\n');
             });
     });
     it('load_single_with_schema', function () {

--- a/test/templatesets/test/complex.yml
+++ b/test/templatesets/test/complex.yml
@@ -33,6 +33,8 @@ definitions:
         <div class="flexbox">{{name}}</div>
         <div class="flexbox">{{msg}}</div>
       </div>
+  fromFile:
+    dataFile: textData.txt
 template: |
   <!DOCTYPE html>
   <html>
@@ -66,6 +68,8 @@ template: |
           {{> chatroom }}
         </div>
       </div>
-      <a href="freeform.yml">next</a>
+      <div>
+        {{fromFile}}
+      </div>
     </body>
   </html>

--- a/test/templatesets/test/textData.txt.data
+++ b/test/templatesets/test/textData.txt.data
@@ -1,0 +1,1 @@
+Lorem ipsum


### PR DESCRIPTION

Sometimes it is desirable to keep a portion of a template in a separate file and include it into the template text.
This can be done with parameters and the `dataFile` property:

```javascript
const fast = require('@f5devcentral/f5-fast-core');

const templatesPath = '/path/to/templatesdir'; // directory containing example.data
const dataProvider = new fast.FsDataProvider(templatesPath);
const yamldata = `
    definitions:
        var:
            dataFile: example
    template: |
        {{var}}
`;

fast.Template.loadYaml(yamldata, { dataProvider })
    .then((template) => {
        console.log(template.getParametersSchema());
        console.log(template.render({virtual_port: 443});
    });
```
The `FsDataProvider` will pick up on any files with the `.data` extension in the template set directory.
When referencing the file in a template, use the filename (without the extension) as a key.

Parameters with a `dataFile` property:

* are removed from `required`
* have their `default` set to the contents of the file
* given a default `format` of `hidden`