### PR TITLE
Fix using object parameters for Mustache sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# v0.21.0
+## Added
+* template: Allow customizing input transform behavior via fast.transformStrategies
+
+## Fixed
+* Fix undefined fast.postProcessStrategies
+* template: Fix using an object parameter as input to a section
+
+## Changed
+* template: JsonTransformStrategy is now only used for 'application/json' contentType
+
 # v0.20.2
 ## Fixed
 * Add CompositeTemplateProvider to index

--- a/index.js
+++ b/index.js
@@ -26,7 +26,9 @@ const {
     CompositeTemplateProvider
 } = require('./lib/template_provider');
 const { GitHubTemplateProvider, GitHubSchemaProvider } = require('./lib/github_provider');
-const { Template, mergeStrategies, postProcessStrategies } = require('./lib/template');
+const {
+    Template, mergeStrategies, postProcessStrategies, transformStrategies
+} = require('./lib/template');
 const guiUtils = require('./lib/gui_utils');
 const TransactionLogger = require('./lib/transaction_logger');
 
@@ -42,6 +44,7 @@ module.exports = {
     Template,
     mergeStrategies,
     postProcessStrategies,
+    transformStrategies,
     guiUtils,
     dataStores,
     TransactionLogger

--- a/lib/template.js
+++ b/lib/template.js
@@ -107,6 +107,13 @@ function nodeHttpToAxios(configObj) {
 }
 
 /**
+ * TransformStrategy for plain text output
+ */
+function PlainTextTransformStrategy(_schema, value) {
+    return value;
+}
+
+/**
  * TransformStrategy for JSON output
  */
 function JsonTransformStrategy(schema, value) {
@@ -132,6 +139,15 @@ function JsonTransformStrategy(schema, value) {
 
     return value;
 }
+
+/**
+ * Object containing available transform strategy functions.
+ * The property is a Content-Type MIME (e.g., `test/plain`).
+ * The value is a TransformStrategy function that accepts the parameter's schema and current value.
+ */
+const transformStrategies = {
+    'application/json': JsonTransformStrategy
+};
 
 /**
  * MergeStrategy for targeting `test/plain` Content-Type
@@ -1070,7 +1086,7 @@ class Template {
      */
     transformParameters(parameters) {
         const schema = this.getParametersSchema();
-        const transform = JsonTransformStrategy;
+        const transform = transformStrategies[this.contentType] || PlainTextTransformStrategy;
         return Object.keys(parameters).reduce((acc, curr) => {
             const value = parameters[curr];
             const valueSchema = schema.properties && schema.properties[curr];
@@ -1255,5 +1271,6 @@ class Template {
 
 module.exports = {
     Template,
-    mergeStrategies
+    mergeStrategies,
+    transformStrategies
 };

--- a/lib/template.js
+++ b/lib/template.js
@@ -1272,5 +1272,6 @@ class Template {
 module.exports = {
     Template,
     mergeStrategies,
+    postProcessStrategies,
     transformStrategies
 };

--- a/lib/template.js
+++ b/lib/template.js
@@ -130,7 +130,9 @@ function JsonTransformStrategy(schema, value) {
         if (!value) {
             return JSON.stringify({});
         }
-        return JSON.stringify(value);
+        if (!schema.skip_xform) {
+            return JSON.stringify(value);
+        }
     }
 
     if (schema.format === 'text' && value) {
@@ -471,6 +473,7 @@ class Template {
                     }
                 } else if (defType === 'object') {
                     Object.assign(newDef, items);
+                    newDef.skip_xform = true;
                 } else if (!asBool) {
                     throw new Error(`unsupported type for section "${defName}": ${defType}`);
                 }

--- a/test/template.js
+++ b/test/template.js
@@ -526,7 +526,7 @@ describe('Template class tests', function () {
                 {{> numbpartial}}
                 {{> arraypartial}}
         `;
-        const reference = 'numb=5\narr=["1","2"]\n';
+        const reference = 'numb=5\narr=1,2\n';
         return Template.loadYaml(ymldata)
             .then((tmpl) => {
                 assert.strictEqual(tmpl.render(), reference);
@@ -604,22 +604,24 @@ describe('Template class tests', function () {
                 assert.strictEqual(schema.properties.virtual_port.type, 'integer');
             });
     });
-    it('render_array', function () {
+    it('render_json_array', function () {
         const mstdata = '{{values::array}}';
         const parameters = { values: ['1', '2', '3'] };
-        const reference = '["1","2","3"]';
+        const reference = '[\n  "1",\n  "2",\n  "3"\n]';
         return Template.loadMst(mstdata)
             .then((tmpl) => {
+                tmpl.contentType = 'application/json';
                 console.log(JSON.stringify(tmpl.getParametersSchema(), null, 2));
                 assert.strictEqual(tmpl.render(parameters), reference);
             });
     });
-    it('render_text', function () {
+    it('render_json_text', function () {
         const mstdata = '{{textvar::text}}';
         const parameters = { textvar: 'multi\nline' };
         const reference = '"multi\\nline"';
         return Template.loadMst(mstdata)
             .then((tmpl) => {
+                tmpl.contentType = 'application/json';
                 console.log(JSON.stringify(tmpl.getParametersSchema(), null, 2));
                 assert.strictEqual(tmpl.render(parameters), reference);
             });

--- a/test/template.js
+++ b/test/template.js
@@ -546,6 +546,28 @@ describe('Template class tests', function () {
                 assert.strictEqual(tmpl.render(view), reference);
             });
     });
+    it('render_section_as_object', function () {
+        const ymldata = `
+            contentType: application/json
+            definitions:
+                obj:
+                    type: object
+            template: |-
+                {{#obj}}{ "prop": {{prop}}}{{/obj}}
+        `;
+        const parameters = {
+            obj: {
+                prop: 'foo'
+            }
+        };
+        const reference = '{\n  "prop": "foo"\n}';
+
+        return Template.loadYaml(ymldata)
+            .then((tmpl) => {
+                console.log(tmpl.getParametersSchema());
+                assert.strictEqual(tmpl.render(parameters), reference);
+            });
+    });
     it('render_section_with_partial', function () {
         const ymldata = `
             parameters:


### PR DESCRIPTION
When rendering JSON, the JsonTransformStrategy would always render a whole object as a string. Now we skip this transform if the object is being used in a section. This is how arrays already behave.

Also, we now only use JsonTransformStrategy when contentType is 'application/json'

NOTE: Templates that were relying on JsonTransformStrategy for 'text/plain' (the default contentType) will need to be updated to use the 'application/json' contentType, or specify a custom TransformStrategy.