### PR TITLE
fix: use JSON format in fromJson()

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -940,6 +940,7 @@ class Template {
         }
         const tmpl = new this();
         Object.assign(tmpl, obj);
+        tmpl.contentType = 'application/json';
         delete tmpl._typeDefinitions;
         delete tmpl._explicitDeps;
         return Promise.resolve()

--- a/test/template.js
+++ b/test/template.js
@@ -112,6 +112,7 @@ describe('Template class tests', function () {
                 return Template.fromJson(JSON.stringify(tmpl));
             })
             .then((jsontmpl) => {
+                tmpl.contentType = 'application/json';
                 delete jsontmpl._parametersValidator;
                 delete tmpl._parametersValidator;
                 assert.deepEqual(jsontmpl, tmpl);
@@ -125,6 +126,7 @@ describe('Template class tests', function () {
                 return Template.fromJson(JSON.parse(JSON.stringify(tmpl)));
             })
             .then((jsontmpl) => {
+                tmpl.contentType = 'application/json';
                 delete jsontmpl._parametersValidator;
                 delete tmpl._parametersValidator;
                 assert.deepEqual(jsontmpl, tmpl);


### PR DESCRIPTION
The Template.contentType defaults to plain/text but it needs to be application/json in Template.fromJson()