### PR TITLE
Improve Parameter Validation Errors

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -733,7 +733,8 @@ class Template {
         const ajv = new Ajv({
             loadSchema,
             unknownFormats: 'ignore',
-            useDefaults: true
+            useDefaults: true,
+            allErrors: true
         });
         ajv.addFormat('text', /.*/);
         ajv.addFormat('hidden', /.*/);
@@ -1067,6 +1068,28 @@ class Template {
         return Object.assign(defaults, mathExprResults);
     }
 
+    _parseValidationErrors(errors) {
+        return errors.map((error) => {
+            const param = error.dataPath
+                .replace('.', ''); // strip leading dot
+            let message = (param !== '') ? `parameter ${param} ${error.message}` : error.message;
+
+            if (error.keyword === 'type') {
+                const typeStr = error.params.type;
+                message = `parameter ${param} should be of type ${typeStr}`;
+            }
+
+            if (error.keyword === 'enum') {
+                const allowedValues = error.params.allowedValues;
+                message = `${message}: ${allowedValues.join(', ')}`;
+            }
+
+            return {
+                message
+            };
+        });
+    }
+
     /**
      * Validate the supplied parameters object against the template's parameter schema
      *
@@ -1075,7 +1098,7 @@ class Template {
     validateParameters(parameters) {
         const combParams = this.getCombinedParameters(parameters);
         if (!this._parametersValidator(combParams)) {
-            const validationErrors = this._parametersValidator.errors;
+            const validationErrors = this._parseValidationErrors(this._parametersValidator.errors);
             const err = Error('paramters failed validation');
             err.validationErrors = validationErrors;
             err.parameters = combParams;

--- a/lib/template.js
+++ b/lib/template.js
@@ -1075,12 +1075,11 @@ class Template {
     validateParameters(parameters) {
         const combParams = this.getCombinedParameters(parameters);
         if (!this._parametersValidator(combParams)) {
-            const errstr = ''
-                + 'Parameters failed validation:\n'
-                + `${JSON.stringify(parameters, null, 2)}\n\n`
-                + 'Validation error:\n'
-                + `${JSON.stringify(this._parametersValidator.errors, null, 2)}`;
-            throw new Error(errstr);
+            const validationErrors = this._parametersValidator.errors;
+            const err = Error('paramters failed validation');
+            err.validationErrors = validationErrors;
+            err.parameters = combParams;
+            throw err;
         }
     }
 


### PR DESCRIPTION
This PR:
* Changes the Error message from `Template.validateParameters()` to be simpler
* Moves validation errors and parameters from the Error message string to `validationErrors` and `parameters` properties on the `Error` object
*  Parses the Ajv validation errors and creates easier to read/understand error messages
* Adds a `--json-output` flag to the CLI to make the CLI output easier to consume programmatically