### PR TITLE
Add tests to cover the CLI

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -16,7 +16,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
     - run: npm run lint
-    - run: npm run coverage
+    - run: npm run coverage.all
   audit:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v0.23.0
+## Fixed
+* cli: Improve JSON output for errors on validateTemplateSet and validate
+* cli: Fix JSON output for validateTemplateSet, packageTemplateSet, and htmlpreview
+
+## Changed
+* template: Include Mustache errors in getValidationErrors()
+
 # v0.22.1
 ## Fixed
 * template: Fix "paramters" typo in validateParameters() error

--- a/cli.js
+++ b/cli.js
@@ -130,21 +130,23 @@ const templateToParametersSchemaGui = templatePath => loadTemplate(templatePath)
         process.exit(1);
     });
 
-const validateParamData = (tmpl, parameters) => {
-    try {
-        tmpl.validateParameters(parameters);
-    } catch (e) {
-        logger.error(e.stack);
-        process.exit(1);
-    }
-};
-
 const validateParameters = (templatePath, parametersPath) => loadTemplateAndParameters(templatePath, parametersPath)
     .then(([tmpl, parameters]) => {
-        validateParamData(tmpl, parameters);
+        tmpl.validateParameters(parameters);
     })
     .catch((e) => {
-        logger.error(e.stack);
+        if (e.validationErrors) {
+            logger.error('parameters failed validation');
+            if (logger.isJSON) {
+                logger.output.templateParameters = e.parameters;
+                logger.output.validationErrors = e.validationErrors;
+            } else {
+                logger.error(JSON.stringify(e.validationErrors, null, 2));
+                logger.error(`\nSupplied parameters:\n${JSON.stringify(e.parameters, null, 2)}`);
+            }
+        } else {
+            logger.error(`parameters failed validation: ${e.stack}`);
+        }
         process.exit(1);
     });
 

--- a/cli.js
+++ b/cli.js
@@ -17,8 +17,6 @@
 
 'use strict';
 
-/* eslint-disable no-console */
-
 const fs = require('fs').promises;
 const path = require('path');
 const yaml = require('js-yaml');
@@ -51,8 +49,12 @@ const setLogger = (argv) => {
             }
         };
         process.on('exit', () => {
+            if (typeof logger.output.error === 'undefined'
+                && typeof logger.output.result === 'undefined') {
+                logger.output.result = '';
+            }
             const msg = JSON.stringify(logger.output);
-            console.log(msg);
+            console.log(msg); // eslint-disable-line no-console
         });
     } else {
         logger = {
@@ -61,13 +63,13 @@ const setLogger = (argv) => {
                 if (typeof msg === 'object') {
                     msg = JSON.stringify(msg, null, 2);
                 }
-                console.log(msg);
+                console.log(msg); // eslint-disable-line no-console
             },
             error: (msg) => {
                 if (typeof msg === 'object') {
                     msg = JSON.stringify(msg, null, 2);
                 }
-                console.error(msg);
+                console.error(msg); // eslint-disable-line no-console
             }
         };
     }
@@ -185,7 +187,7 @@ const validateTemplateSet = (tsPath) => {
             templateList.map(
                 tmpl => provider.fetch(tmpl)
                     .catch((e) => {
-                        console.error(
+                        logger.error(
                             `Template "${tmpl}" failed validation:\n${e.stack}\n`
                         );
                         errorFound = true;
@@ -195,12 +197,12 @@ const validateTemplateSet = (tsPath) => {
         ))
         .then(() => {
             if (errorFound) {
-                console.error(`Template set "${tsName}" failed validation`);
+                logger.error(`Template set "${tsName}" failed validation`);
                 process.exit(1);
             }
         })
         .catch((e) => {
-            console.error(`Template set "${tsName}" failed validation:\n${e.stack}`);
+            logger.error(`Template set "${tsName}" failed validation:\n${e.stack}`);
             process.exit(1);
         });
 };
@@ -210,7 +212,7 @@ const htmlPreview = (templatePath, parametersPath) => loadTemplateAndParameters(
         tmpl.getParametersSchema(),
         tmpl.getCombinedParameters(parameters)
     ))
-    .then(htmlData => console.log(htmlData));
+    .then(htmlData => logger.log(htmlData));
 
 const packageTemplateSet = (tsPath, dst) => validateTemplateSet(tsPath)
     .then(() => {
@@ -222,7 +224,7 @@ const packageTemplateSet = (tsPath, dst) => validateTemplateSet(tsPath)
 
         return provider.buildPackage(tsName, dst)
             .then(() => {
-                console.log(`Template set "${tsName}" packaged as ${dst}`);
+                logger.log(`Template set "${tsName}" packaged as ${dst}`);
             });
     });
 

--- a/lib/template.js
+++ b/lib/template.js
@@ -68,6 +68,7 @@ const getRefDefs = (schema) => {
 const validator = new Ajv();
 
 // meta-schema uses a mustache format; just parse the string validate it
+const _mustacheErrors = [];
 validator.addFormat('mustache', {
     type: 'string',
     validate(input) {
@@ -75,8 +76,10 @@ validator.addFormat('mustache', {
             Mustache.parse(input);
             return true;
         } catch (e) {
-            // TODO find a better way to report issues here
-            console.log(e); /* eslint-disable-line no-console */
+            _mustacheErrors.push({
+                keyword: 'mustache',
+                message: e.message
+            });
             return false;
         }
     }
@@ -966,6 +969,7 @@ class Template {
      * @returns {boolean}
      */
     static isValid(tmpldata) {
+        _mustacheErrors.splice(0);
         return _validateSchema(tmpldata);
     }
 
@@ -975,7 +979,7 @@ class Template {
      * @returns {string}
      */
     static getValidationErrors() {
-        return JSON.stringify(_validateSchema.errors, null, 2);
+        return JSON.stringify([..._mustacheErrors, ..._validateSchema.errors], null, 2);
     }
 
     /**

--- a/lib/template.js
+++ b/lib/template.js
@@ -78,7 +78,8 @@ validator.addFormat('mustache', {
         } catch (e) {
             _mustacheErrors.push({
                 keyword: 'mustache',
-                message: e.message
+                dataPath: '',
+                message: `invalid template text: ${e.message}`
             });
             return false;
         }
@@ -989,7 +990,13 @@ class Template {
      */
     static validate(tmpldata) {
         if (!this.isValid(tmpldata)) {
-            throw new Error(this.getValidationErrors());
+            const validationErrors = this._parseValidationErrors([
+                ..._mustacheErrors,
+                ..._validateSchema.errors
+            ]);
+            const err = Error('template failed validation');
+            err.validationErrors = validationErrors;
+            throw err;
         }
     }
 
@@ -1072,7 +1079,7 @@ class Template {
         return Object.assign(defaults, mathExprResults);
     }
 
-    _parseValidationErrors(errors) {
+    static _parseValidationErrors(errors) {
         return errors.map((error) => {
             const param = error.dataPath
                 .replace('.', ''); // strip leading dot
@@ -1102,7 +1109,7 @@ class Template {
     validateParameters(parameters) {
         const combParams = this.getCombinedParameters(parameters);
         if (!this._parametersValidator(combParams)) {
-            const validationErrors = this._parseValidationErrors(this._parametersValidator.errors);
+            const validationErrors = Template._parseValidationErrors(this._parametersValidator.errors);
             const err = Error('parameters failed validation');
             err.validationErrors = validationErrors;
             err.parameters = combParams;

--- a/package.json
+++ b/package.json
@@ -7,10 +7,13 @@
   "main": "index.js",
   "description": "The core module for F5 Application Services Templates",
   "scripts": {
-    "test": "mocha --recursive \"./test/*.js\"",
+    "test": "mocha --exclude test/cli.js",
+    "test.cli": "mocha test/setup-logging.js test/cli.js",
+    "test.all": "mocha",
     "lint": "eslint lib test index.js cli.js --ignore-pattern jsoneditor.js",
     "buildbin": "./scripts/build-fastbin.sh",
-    "coverage": "nyc -r text -r html npm test"
+    "coverage": "nyc -r text -r html npm test",
+    "coverage.all": "nyc -r text -r html npm run test.all"
   },
   "keywords": [
     "as3",
@@ -51,7 +54,8 @@
   "nyc": {
     "all": true,
     "include": [
-      "lib/**/*.js"
+      "lib/**/*.js",
+      "cli.js"
     ],
     "exclude": [
       "lib/jsoneditor.js"

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,0 +1,283 @@
+/* Copyright 2021 F5 Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable prefer-arrow-callback */
+/* eslint-disable func-names */
+/* eslint-disable no-console */
+
+'use strict';
+
+const { exec } = require('child_process');
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+const assert = require('assert');
+
+const templateSetDir = path.join(__dirname, 'templatesets', 'test');
+const templateSimplePath = path.join(templateSetDir, 'simple.yaml');
+
+async function executeCommand(commandStr) {
+    const cmd = `node ${path.join('..', 'cli.js')} ${commandStr}`;
+    console.log(`running: ${cmd}`);
+    return new Promise((resolve, reject) => {
+        exec(cmd, { cwd: __dirname }, (error, stdout, stderr) => {
+            if (error) {
+                error.stdout = stdout;
+                error.stderr = stderr;
+                reject(error);
+            }
+
+            resolve({ stdout, stderr });
+        });
+    });
+}
+
+describe('CLI tests', function () {
+    let tmpDir = null;
+    const mktmpdir = () => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fast'));
+    };
+
+    const rmtmpdir = () => {
+        if (tmpDir !== null) {
+            if (fs.rmSync) {
+                fs.rmSync(tmpDir, { recursive: true });
+            } else {
+                // Older Node version
+                fs.rmdirSync(tmpDir, { recursive: true });
+            }
+            tmpDir = null;
+        }
+    };
+
+    afterEach(rmtmpdir);
+
+    describe('validate', function () {
+        it('should succeed on valid template', async function () {
+            const { stdout } = await executeCommand(`validate ${templateSimplePath}`);
+            assert.match(stdout, /template source at .* is valid/);
+        });
+        it('should fail on invalid template', async function () {
+            const invalidTemplatePath = path.join(__dirname, 'invalid_templatesets', 'invalid', 'invalid.yaml');
+            return executeCommand(`validate ${invalidTemplatePath}`)
+                .then(() => assert(false, 'Expected command to fail'))
+                .catch((e) => {
+                    console.log(e);
+                    assert.match(e.stderr, /failed to load template/);
+                });
+        });
+        it('should support JSON output', async function () {
+            const { stdout } = await executeCommand(`validate --json-output ${templateSimplePath}`);
+            const output = JSON.parse(stdout);
+            assert.match(output.result, /template source at .* is valid/);
+        });
+        it('should support JSON error output', async function () {
+            const invalidTemplatePath = path.join(__dirname, 'invalid_templatesets', 'invalid', 'invalid.yaml');
+            return executeCommand(`validate --json-output ${invalidTemplatePath}`)
+                .then(() => assert(false, 'Expected command to fail'))
+                .catch((e) => {
+                    const output = JSON.parse(e.stdout);
+                    console.log(output);
+                    assert.match(output.error, /failed to load template/);
+                });
+        });
+    });
+    describe('schema', function () {
+        it('should output template parameters schema', async function () {
+            const { stdout } = await executeCommand(`schema ${templateSimplePath}`);
+            const schema = JSON.parse(stdout);
+            assert.ok(schema.properties.str_var);
+            assert.match(schema.title, /Simple YAML file/);
+        });
+        it('should support JSON output', async function () {
+            const { stdout } = await executeCommand(`schema --json-output ${templateSimplePath}`);
+            const output = JSON.parse(stdout);
+            const schema = output.result;
+            assert.ok(schema.properties.str_var);
+            assert.match(schema.title, /Simple YAML file/);
+        });
+    });
+    describe('guiSchema', function () {
+        it('should output gui-friendly template parameters schema', async function () {
+            const { stdout } = await executeCommand(`guiSchema ${templateSimplePath}`);
+            const schema = JSON.parse(stdout);
+            assert.ok(schema.properties.str_var);
+            assert.match(schema.title, /Simple YAML file/);
+        });
+        it('should support JSON output', async function () {
+            const { stdout } = await executeCommand(`guiSchema --json-output ${templateSimplePath}`);
+            const output = JSON.parse(stdout);
+            const schema = output.result;
+            assert.ok(schema.properties.str_var);
+            assert.match(schema.title, /Simple YAML file/);
+        });
+    });
+    describe('validateParameters', function () {
+        it('should succeed on valid parameters', async function () {
+            mktmpdir();
+            const viewPath = path.join(tmpDir, 'view.json');
+            fs.writeFileSync(viewPath, JSON.stringify({ str_var: 'bar' }));
+            const { stdout } = await executeCommand(`validateParameters ${templateSimplePath} ${viewPath}`);
+            assert.strictEqual(stdout, '');
+        });
+        it('should fail on invalid parameters', async function () {
+            mktmpdir();
+            const viewPath = path.join(tmpDir, 'view.json');
+            fs.writeFileSync(viewPath, JSON.stringify({ str_var: 5 }));
+            return executeCommand(`validateParameters ${templateSimplePath} ${viewPath}`)
+                .then(() => assert(false, 'Expected command to fail'))
+                .catch((e) => {
+                    console.log(e);
+                    assert.match(e.stderr, /parameters failed validation/);
+                });
+        });
+        it('should support JSON output', async function () {
+            mktmpdir();
+            const viewPath = path.join(tmpDir, 'view.json');
+            fs.writeFileSync(viewPath, JSON.stringify({ str_var: 'bar' }));
+            const { stdout } = await executeCommand(`validateParameters --json-output ${templateSimplePath} ${viewPath}`);
+            const output = JSON.parse(stdout);
+            assert.strictEqual(output.result, '');
+        });
+        it('should support JSON error output', async function () {
+            mktmpdir();
+            const viewPath = path.join(tmpDir, 'view.json');
+            fs.writeFileSync(viewPath, JSON.stringify({ str_var: 5 }));
+            return executeCommand(`validateParameters --json-output ${templateSimplePath} ${viewPath}`)
+                .then(() => assert(false, 'Expected command to fail'))
+                .catch((e) => {
+                    const output = JSON.parse(e.stdout);
+                    console.log(output);
+                    assert.match(output.error, /parameters failed validation/);
+                    assert.deepStrictEqual(
+                        output.templateParameters,
+                        {
+                            str_var: 5
+                        }
+                    );
+                    assert.deepStrictEqual(
+                        output.validationErrors,
+                        [
+                            { message: 'parameter str_var should be of type string' }
+                        ]
+                    );
+                });
+        });
+    });
+    describe('render', function () {
+        it('should render template to stdout', async function () {
+            const { stdout } = await executeCommand(`render ${templateSimplePath}`);
+            assert.match(stdout, /foo/);
+        });
+        it('should fail on invalid parameters', async function () {
+            mktmpdir();
+            const viewPath = path.join(tmpDir, 'view.json');
+            fs.writeFileSync(viewPath, JSON.stringify({ str_var: 5 }));
+            return executeCommand(`render ${templateSimplePath} ${viewPath}`)
+                .then(() => assert(false, 'Expected command to fail'))
+                .catch((e) => {
+                    console.log(e);
+                    assert.match(e.stderr, /Failed to render template since parameters failed validation/);
+                });
+        });
+        it('should support JSON output', async function () {
+            const { stdout } = await executeCommand(`render --json-output ${templateSimplePath}`);
+            const output = JSON.parse(stdout);
+            assert.match(output.result, /foo/);
+        });
+        it('should support JSON error output', async function () {
+            mktmpdir();
+            const viewPath = path.join(tmpDir, 'view.json');
+            fs.writeFileSync(viewPath, JSON.stringify({ str_var: 5 }));
+            return executeCommand(`render --json-output ${templateSimplePath} ${viewPath}`)
+                .then(() => assert(false, 'Expected command to fail'))
+                .catch((e) => {
+                    const output = JSON.parse(e.stdout);
+                    console.log(output);
+                    assert.match(output.error, /parameters failed validation/);
+                    assert.deepStrictEqual(
+                        output.templateParameters,
+                        {
+                            str_var: 5
+                        }
+                    );
+                    assert.deepStrictEqual(
+                        output.validationErrors,
+                        [
+                            { message: 'parameter str_var should be of type string' }
+                        ]
+                    );
+                });
+        });
+    });
+    describe('validateTemplateSet', function () {
+        it('should succeed on valid template set', async function () {
+            const { stdout } = await executeCommand(`validateTemplateSet ${templateSetDir}`);
+            assert.strictEqual(stdout, '');
+        });
+        it('should fail on invalid template set', async function () {
+            const invalidSetPath = path.join(__dirname, 'invalid_templatesets', 'invalid');
+            return executeCommand(`validateTemplateSet ${invalidSetPath}`)
+                .then(() => assert(false, 'Expected command to fail'))
+                .catch((e) => {
+                    console.log(e);
+                    assert.match(e.stderr, /Template .* failed validation/);
+                });
+        });
+        it('should support JSON output', async function () {
+            const { stdout } = await executeCommand(`validateTemplateSet --json-output ${templateSetDir}`);
+            const output = JSON.parse(stdout);
+            assert.strictEqual(output.result, '');
+        });
+        it('should support JSON error output', async function () {
+            const invalidSetPath = path.join(__dirname, 'invalid_templatesets', 'invalid');
+            return executeCommand(`validateTemplateSet --json-output ${invalidSetPath}`)
+                .then(() => assert(false, 'Expected command to fail'))
+                .catch((e) => {
+                    const output = JSON.parse(e.stdout);
+                    console.log(output);
+                    assert.match(output.error, /Template set .* failed validation/);
+                    assert.match(output.errors[0].message, /Template .* failed validation/);
+                    assert.match(output.errors[0].validationErrors[0].message, /invalid template text/);
+                });
+        });
+    });
+    describe('htmlpreview', function () {
+        it('should generate a static HTML page to stdout', async function () {
+            const { stdout } = await executeCommand(`htmlpreview ${templateSimplePath}`);
+            assert.match(stdout, /doctype html/);
+        });
+        it('should support JSON output', async function () {
+            const { stdout } = await executeCommand(`htmlpreview --json-output ${templateSimplePath}`);
+            const output = JSON.parse(stdout);
+            assert.match(output.result, /doctype html/);
+        });
+    });
+    describe('packageTemplateSet', function () {
+        it('should create a package for the given template set', async function () {
+            mktmpdir();
+            const pkgpath = path.join(tmpDir, 'pkg.zip');
+            const { stdout } = await executeCommand(`packageTemplateSet ${templateSetDir} ${pkgpath}`);
+            assert.match(stdout, /Template set "test" packaged as .*\/pkg.zip/);
+        });
+        it('should support JSON output', async function () {
+            mktmpdir();
+            const pkgpath = path.join(tmpDir, 'pkg.zip');
+            const { stdout } = await executeCommand(`packageTemplateSet --json-output ${templateSetDir} ${pkgpath}`);
+            const output = JSON.parse(stdout);
+            assert.match(output.result, /Template set "test" packaged as .*\/pkg.zip/);
+        });
+    });
+});

--- a/test/invalid_templatesets/invalid/invalid.yaml
+++ b/test/invalid_templatesets/invalid/invalid.yaml
@@ -1,0 +1,2 @@
+title: Invalid
+template: {{foo}


### PR DESCRIPTION
This PR adds tests to provide coverage on the CLI and to ensure CLI output remains stable. These new tests are a fair amount slower than the other unit tests, so I have excluded them from `test` and made a `test.all` NPM script to run the existing unit tests along with the new CLI tests.

This PR also introduces some various fixes to issues found while writing tests (primarily around JSON output).