### PR TITLE
template: Make validation errors from failed pattern matches shorter

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -1092,8 +1092,8 @@ class Template {
             }
 
             if (error.keyword === 'enum') {
-                const allowedValues = error.params.allowedValues;
-                message = `${message}: ${allowedValues.join(', ')}`;
+                const allowedValues = error.params.allowedValues.join(', ');
+                details = `allowed values are: ${allowedValues}`;
             }
 
             if (error.keyword === 'pattern') {

--- a/lib/template.js
+++ b/lib/template.js
@@ -1084,6 +1084,7 @@ class Template {
             const param = error.dataPath
                 .replace('.', ''); // strip leading dot
             let message = (param !== '') ? `parameter ${param} ${error.message}` : error.message;
+            let details = null;
 
             if (error.keyword === 'type') {
                 const typeStr = error.params.type;
@@ -1095,9 +1096,17 @@ class Template {
                 message = `${message}: ${allowedValues.join(', ')}`;
             }
 
-            return {
-                message
-            };
+            if (error.keyword === 'pattern') {
+                message = `parameter ${param} should match pattern`;
+                details = `failed to match pattern: ${error.params.pattern}`;
+            }
+
+            const newError = { message };
+            if (details) {
+                newError.details = details;
+            }
+
+            return newError;
         });
     }
 

--- a/test/template.js
+++ b/test/template.js
@@ -1349,7 +1349,8 @@ describe('Template class tests', function () {
                             message: 'parameter fooArray[1] should be of type string'
                         },
                         {
-                            message: 'parameter fooEnum should be equal to one of the allowed values: foo, bar'
+                            message: 'parameter fooEnum should be equal to one of the allowed values',
+                            details: 'allowed values are: foo, bar'
                         },
                         {
                             message: 'parameter foo should be of type string'

--- a/test/template.js
+++ b/test/template.js
@@ -1436,4 +1436,27 @@ describe('Template class tests', function () {
                 });
             });
     });
+    it('validate_pattern', function () {
+        const yamldata = `
+            definitions:
+                foo:
+                    pattern: bar
+            parameters:
+                foo: foo
+            template: |-
+                {{foo}}
+        `;
+
+        return Template.loadYaml(yamldata)
+            .then((tmpl) => {
+                assert.throws(() => tmpl.validateParameters(), {
+                    validationErrors: [
+                        {
+                            message: 'parameter foo should match pattern',
+                            details: 'failed to match pattern: bar'
+                        }
+                    ]
+                });
+            });
+    });
 });


### PR DESCRIPTION
The pattern that was failed to match has been moved from "message" to "details". The regex pattern can get very long, so to keep messages short, it will now always be in "details".