### PR TITLE
fix: provide more useful error message on duplicate keys in template

### DIFF
--- a/lib/github_provider.js
+++ b/lib/github_provider.js
@@ -68,7 +68,7 @@ class GitHubContentsApi {
                 }
             }))
             .catch(e => this._handleResponseError(e, `get contents for ${contentPath}`))
-            .then(resp => JSON.parse(resp.data).content)
+            .then(resp => resp.data.content)
             .then(data => Buffer.from(data, 'base64').toString('utf8'));
     }
 }

--- a/lib/template.js
+++ b/lib/template.js
@@ -201,7 +201,7 @@ function JsonPostProcessStrategy(rendered) {
     if (rendered.trim() === '') {
         rendered = '""';
     }
-    return JSON.stringify(yaml.load(rendered) || '', null, 2);
+    return JSON.stringify(LoadYamlWithDuplicateKeyCheck(rendered) || '', null, 2);
 }
 
 /**
@@ -211,7 +211,32 @@ function YamlPostProcessStrategy(rendered) {
     if (rendered.trim() === '') {
         rendered = '""';
     }
-    return yaml.dump(yaml.load(rendered));
+    return yaml.dump(LoadYamlWithDuplicateKeyCheck(rendered));
+}
+
+/**
+ * LoadYamlWithDuplicateKeyCheck will load a yaml string
+ * and throw a custom error response if duplicate mapping keys exist
+ */
+function LoadYamlWithDuplicateKeyCheck(str) {
+    const duplicateKeyRegex = /"(.*?)"/g;
+    try {
+        return yaml.load(str);
+    } catch (e) {
+        if (e.message.match(/^duplicated mapping key/)) {
+            const seenKeys = new Set();
+            let match;
+            // eslint-disable-next-line no-cond-assign
+            while ((match = duplicateKeyRegex.exec(e.message)) !== null) {
+                const matchContents = match[1];
+                if (seenKeys.has(matchContents)) {
+                    throw new Error(`parameters must have unique values. The parameter value "${matchContents}" is duplicated across parameters and you must update the parameter values to ensure they are unique.`);
+                }
+                seenKeys.add(matchContents);
+            }
+        }
+        throw e;
+    }
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,92 @@
         "js-yaml": "^4.1.0"
       }
     },
+    "@babel/code-frame": {
+      "version": "7.24.2",
+      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/code-frame/-/code-frame-7.24.2.tgz",
+      "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.24.2",
+        "picocolors": "^1.0.0"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.24.5",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
+          "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.24.5",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/highlight/-/highlight-7.24.5.tgz",
+          "integrity": "sha512-8lLmua6AVh/8SLJRRVD6V8p73Hir9w5mJrhE+IPpILG31KKlI9iz5zmBYKcWPS59qSfgP9RaSBQSHHE81WKuEw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.24.5",
+            "chalk": "^2.4.2",
+            "js-tokens": "^4.0.0",
+            "picocolors": "^1.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/ansi-styles/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/color-name/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/escape-string-regexp/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/has-flag/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "@babel/compat-data": {
       "version": "7.13.8",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.8.tgz",
@@ -105,24 +191,84 @@
         }
       }
     },
+    "@babel/helper-environment-visitor": {
+      "version": "7.22.20",
+      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+      "dev": true
+    },
     "@babel/helper-function-name": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
-      "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+      "version": "7.23.0",
+      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.12.13",
-        "@babel/template": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/template": "^7.22.15",
+        "@babel/types": "^7.23.0"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.24.5",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
+          "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
+          "dev": true
+        },
+        "@babel/parser": {
+          "version": "7.24.5",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/parser/-/parser-7.24.5.tgz",
+          "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.24.0",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/template/-/template-7.24.0.tgz",
+          "integrity": "sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.23.5",
+            "@babel/parser": "^7.24.0",
+            "@babel/types": "^7.24.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.24.5",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/types/-/types-7.24.5.tgz",
+          "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-string-parser": "^7.24.1",
+            "@babel/helper-validator-identifier": "^7.24.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
-    "@babel/helper-get-function-arity": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
-      "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+    "@babel/helper-hoist-variables": {
+      "version": "7.22.5",
+      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.22.5"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.24.5",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
+          "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.24.5",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/types/-/types-7.24.5.tgz",
+          "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-string-parser": "^7.24.1",
+            "@babel/helper-validator-identifier": "^7.24.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -198,6 +344,12 @@
       "requires": {
         "@babel/types": "^7.12.13"
       }
+    },
+    "@babel/helper-string-parser": {
+      "version": "7.24.1",
+      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
+      "integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
+      "dev": true
     },
     "@babel/helper-validator-identifier": {
       "version": "7.12.11",
@@ -320,34 +472,70 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.0.tgz",
-      "integrity": "sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==",
+      "version": "7.24.5",
+      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/traverse/-/traverse-7.24.5.tgz",
+      "integrity": "sha512-7aaBLeDQ4zYcUFDUD41lJc1fG8+5IU9DaNSJAgal866FGvmD5EbWQgnEC6kO1gGLsX0esNkfnJSndbTXA3r7UA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.13.0",
-        "@babel/helper-function-name": "^7.12.13",
-        "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/parser": "^7.13.0",
-        "@babel/types": "^7.13.0",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.19"
+        "@babel/code-frame": "^7.24.2",
+        "@babel/generator": "^7.24.5",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
+        "@babel/helper-hoist-variables": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.24.5",
+        "@babel/parser": "^7.24.5",
+        "@babel/types": "^7.24.5",
+        "debug": "^4.3.1",
+        "globals": "^11.1.0"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+        "@babel/generator": {
+          "version": "7.24.5",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/generator/-/generator-7.24.5.tgz",
+          "integrity": "sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.12.13"
+            "@babel/types": "^7.24.5",
+            "@jridgewell/gen-mapping": "^0.3.5",
+            "@jridgewell/trace-mapping": "^0.3.25",
+            "jsesc": "^2.5.1"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.24.5",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.5.tgz",
+          "integrity": "sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.24.5"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.24.5",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
+          "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
+          "dev": true
+        },
+        "@babel/parser": {
+          "version": "7.24.5",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/parser/-/parser-7.24.5.tgz",
+          "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.24.5",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/types/-/types-7.24.5.tgz",
+          "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-string-parser": "^7.24.1",
+            "@babel/helper-validator-identifier": "^7.24.5",
+            "to-fast-properties": "^2.0.0"
           }
         },
         "globals": {
           "version": "11.12.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/globals/-/globals-11.12.0.tgz",
           "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
           "dev": true
         }
@@ -545,6 +733,45 @@
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
+    },
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.5",
+      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.2.1",
+      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.25",
+      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "@jsdevtools/ono": {
       "version": "7.1.3",
@@ -2313,9 +2540,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q=="
+      "version": "1.15.6",
+      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -4073,6 +4300,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true
+    },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
       "dev": true
     },
     "picomatch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,92 +21,6 @@
         "js-yaml": "^4.1.0"
       }
     },
-    "@babel/code-frame": {
-      "version": "7.24.2",
-      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/code-frame/-/code-frame-7.24.2.tgz",
-      "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
-      "dev": true,
-      "requires": {
-        "@babel/highlight": "^7.24.2",
-        "picocolors": "^1.0.0"
-      },
-      "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.24.5",
-          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
-          "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
-          "dev": true
-        },
-        "@babel/highlight": {
-          "version": "7.24.5",
-          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/highlight/-/highlight-7.24.5.tgz",
-          "integrity": "sha512-8lLmua6AVh/8SLJRRVD6V8p73Hir9w5mJrhE+IPpILG31KKlI9iz5zmBYKcWPS59qSfgP9RaSBQSHHE81WKuEw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.24.5",
-            "chalk": "^2.4.2",
-            "js-tokens": "^4.0.0",
-            "picocolors": "^1.0.0"
-          }
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/ansi-styles/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/color-name/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/escape-string-regexp/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/has-flag/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
     "@babel/compat-data": {
       "version": "7.13.8",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.8.tgz",
@@ -191,84 +105,24 @@
         }
       }
     },
-    "@babel/helper-environment-visitor": {
-      "version": "7.22.20",
-      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
-      "dev": true
-    },
     "@babel/helper-function-name": {
-      "version": "7.23.0",
-      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+      "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.22.15",
-        "@babel/types": "^7.23.0"
-      },
-      "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.24.5",
-          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
-          "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
-          "dev": true
-        },
-        "@babel/parser": {
-          "version": "7.24.5",
-          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/parser/-/parser-7.24.5.tgz",
-          "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.24.0",
-          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/template/-/template-7.24.0.tgz",
-          "integrity": "sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.23.5",
-            "@babel/parser": "^7.24.0",
-            "@babel/types": "^7.24.0"
-          }
-        },
-        "@babel/types": {
-          "version": "7.24.5",
-          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/types/-/types-7.24.5.tgz",
-          "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-string-parser": "^7.24.1",
-            "@babel/helper-validator-identifier": "^7.24.5",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
+        "@babel/helper-get-function-arity": "^7.12.13",
+        "@babel/template": "^7.12.13",
+        "@babel/types": "^7.12.13"
       }
     },
-    "@babel/helper-hoist-variables": {
-      "version": "7.22.5",
-      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
+    "@babel/helper-get-function-arity": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+      "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.22.5"
-      },
-      "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.24.5",
-          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
-          "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.24.5",
-          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/types/-/types-7.24.5.tgz",
-          "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-string-parser": "^7.24.1",
-            "@babel/helper-validator-identifier": "^7.24.5",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
+        "@babel/types": "^7.12.13"
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -344,12 +198,6 @@
       "requires": {
         "@babel/types": "^7.12.13"
       }
-    },
-    "@babel/helper-string-parser": {
-      "version": "7.24.1",
-      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
-      "integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
-      "dev": true
     },
     "@babel/helper-validator-identifier": {
       "version": "7.12.11",
@@ -472,70 +320,34 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.24.5",
-      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/traverse/-/traverse-7.24.5.tgz",
-      "integrity": "sha512-7aaBLeDQ4zYcUFDUD41lJc1fG8+5IU9DaNSJAgal866FGvmD5EbWQgnEC6kO1gGLsX0esNkfnJSndbTXA3r7UA==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.0.tgz",
+      "integrity": "sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.24.2",
-        "@babel/generator": "^7.24.5",
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.24.5",
-        "@babel/parser": "^7.24.5",
-        "@babel/types": "^7.24.5",
-        "debug": "^4.3.1",
-        "globals": "^11.1.0"
+        "@babel/code-frame": "^7.12.13",
+        "@babel/generator": "^7.13.0",
+        "@babel/helper-function-name": "^7.12.13",
+        "@babel/helper-split-export-declaration": "^7.12.13",
+        "@babel/parser": "^7.13.0",
+        "@babel/types": "^7.13.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.19"
       },
       "dependencies": {
-        "@babel/generator": {
-          "version": "7.24.5",
-          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/generator/-/generator-7.24.5.tgz",
-          "integrity": "sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==",
+        "@babel/code-frame": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.24.5",
-            "@jridgewell/gen-mapping": "^0.3.5",
-            "@jridgewell/trace-mapping": "^0.3.25",
-            "jsesc": "^2.5.1"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.24.5",
-          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.5.tgz",
-          "integrity": "sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.24.5"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.24.5",
-          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
-          "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
-          "dev": true
-        },
-        "@babel/parser": {
-          "version": "7.24.5",
-          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/parser/-/parser-7.24.5.tgz",
-          "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.24.5",
-          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/types/-/types-7.24.5.tgz",
-          "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-string-parser": "^7.24.1",
-            "@babel/helper-validator-identifier": "^7.24.5",
-            "to-fast-properties": "^2.0.0"
+            "@babel/highlight": "^7.12.13"
           }
         },
         "globals": {
           "version": "11.12.0",
-          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/globals/-/globals-11.12.0.tgz",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
           "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
           "dev": true
         }
@@ -733,45 +545,6 @@
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
-    },
-    "@jridgewell/gen-mapping": {
-      "version": "0.3.5",
-      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true
-    },
-    "@jridgewell/set-array": {
-      "version": "1.2.1",
-      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true
-    },
-    "@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
-    },
-    "@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
     },
     "@jsdevtools/ono": {
       "version": "7.1.3",
@@ -1682,7 +1455,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "available-typed-arrays": {
       "version": "1.0.5",
@@ -1691,13 +1464,12 @@
       "dev": true
     },
     "axios": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
-      "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "requires": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
       }
     },
     "balanced-match": {
@@ -2057,7 +1829,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "diff": {
       "version": "5.0.0",
@@ -2540,9 +2312,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
+      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -4302,12 +4074,6 @@
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true
     },
-    "picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
-    },
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -4340,11 +4106,6 @@
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
       "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
       "dev": true
-    },
-    "proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "punycode": {
       "version": "2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,92 @@
         "js-yaml": "^4.1.0"
       }
     },
+    "@babel/code-frame": {
+      "version": "7.24.2",
+      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/code-frame/-/code-frame-7.24.2.tgz",
+      "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.24.2",
+        "picocolors": "^1.0.0"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.24.5",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
+          "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.24.5",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/highlight/-/highlight-7.24.5.tgz",
+          "integrity": "sha512-8lLmua6AVh/8SLJRRVD6V8p73Hir9w5mJrhE+IPpILG31KKlI9iz5zmBYKcWPS59qSfgP9RaSBQSHHE81WKuEw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.24.5",
+            "chalk": "^2.4.2",
+            "js-tokens": "^4.0.0",
+            "picocolors": "^1.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/ansi-styles/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/color-name/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/escape-string-regexp/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/has-flag/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "@babel/compat-data": {
       "version": "7.13.8",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.8.tgz",
@@ -105,24 +191,84 @@
         }
       }
     },
+    "@babel/helper-environment-visitor": {
+      "version": "7.22.20",
+      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+      "dev": true
+    },
     "@babel/helper-function-name": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
-      "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+      "version": "7.23.0",
+      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.12.13",
-        "@babel/template": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/template": "^7.22.15",
+        "@babel/types": "^7.23.0"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.24.5",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
+          "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
+          "dev": true
+        },
+        "@babel/parser": {
+          "version": "7.24.5",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/parser/-/parser-7.24.5.tgz",
+          "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.24.0",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/template/-/template-7.24.0.tgz",
+          "integrity": "sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.23.5",
+            "@babel/parser": "^7.24.0",
+            "@babel/types": "^7.24.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.24.5",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/types/-/types-7.24.5.tgz",
+          "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-string-parser": "^7.24.1",
+            "@babel/helper-validator-identifier": "^7.24.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
-    "@babel/helper-get-function-arity": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
-      "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+    "@babel/helper-hoist-variables": {
+      "version": "7.22.5",
+      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.22.5"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.24.5",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
+          "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.24.5",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/types/-/types-7.24.5.tgz",
+          "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-string-parser": "^7.24.1",
+            "@babel/helper-validator-identifier": "^7.24.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -198,6 +344,12 @@
       "requires": {
         "@babel/types": "^7.12.13"
       }
+    },
+    "@babel/helper-string-parser": {
+      "version": "7.24.1",
+      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
+      "integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
+      "dev": true
     },
     "@babel/helper-validator-identifier": {
       "version": "7.12.11",
@@ -320,34 +472,70 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.0.tgz",
-      "integrity": "sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==",
+      "version": "7.24.5",
+      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/traverse/-/traverse-7.24.5.tgz",
+      "integrity": "sha512-7aaBLeDQ4zYcUFDUD41lJc1fG8+5IU9DaNSJAgal866FGvmD5EbWQgnEC6kO1gGLsX0esNkfnJSndbTXA3r7UA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.13.0",
-        "@babel/helper-function-name": "^7.12.13",
-        "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/parser": "^7.13.0",
-        "@babel/types": "^7.13.0",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.19"
+        "@babel/code-frame": "^7.24.2",
+        "@babel/generator": "^7.24.5",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
+        "@babel/helper-hoist-variables": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.24.5",
+        "@babel/parser": "^7.24.5",
+        "@babel/types": "^7.24.5",
+        "debug": "^4.3.1",
+        "globals": "^11.1.0"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+        "@babel/generator": {
+          "version": "7.24.5",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/generator/-/generator-7.24.5.tgz",
+          "integrity": "sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.12.13"
+            "@babel/types": "^7.24.5",
+            "@jridgewell/gen-mapping": "^0.3.5",
+            "@jridgewell/trace-mapping": "^0.3.25",
+            "jsesc": "^2.5.1"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.24.5",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.5.tgz",
+          "integrity": "sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.24.5"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.24.5",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
+          "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
+          "dev": true
+        },
+        "@babel/parser": {
+          "version": "7.24.5",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/parser/-/parser-7.24.5.tgz",
+          "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.24.5",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@babel/types/-/types-7.24.5.tgz",
+          "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-string-parser": "^7.24.1",
+            "@babel/helper-validator-identifier": "^7.24.5",
+            "to-fast-properties": "^2.0.0"
           }
         },
         "globals": {
           "version": "11.12.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/globals/-/globals-11.12.0.tgz",
           "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
           "dev": true
         }
@@ -545,6 +733,45 @@
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
+    },
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.5",
+      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.2.1",
+      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.25",
+      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "@jsdevtools/ono": {
       "version": "7.1.3",
@@ -2312,9 +2539,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
-      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ=="
+      "version": "1.15.6",
+      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -4072,6 +4299,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true
+    },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.f5net.com:443/artifactory/api/npm/npm-all/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
       "dev": true
     },
     "picomatch": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@f5devcentral/atg-storage": "^1.3.9",
     "adm-zip": "^0.5.10",
     "ajv": "^6.12.6",
-    "axios": "^1.6.0",
+    "axios": "^0.27.2",
     "deepmerge": "^4.3.1",
     "js-yaml": "^4.1.0",
     "jsonpath-plus": "^4.0.0",

--- a/test/template.js
+++ b/test/template.js
@@ -745,6 +745,21 @@ describe('Template class tests', function () {
                 assert.strictEqual(tmpl.render(), reference);
             });
     });
+    it('render_json_duplicate_keys', function () {
+        const yamldata = `
+            contentType: application/json
+            template: |
+                data:
+                    "{{KeyOne}}": "value1"
+                    "{{KeyTwo}}": "value2"
+        `;
+        const duplicateValue = 'duplicate_key';
+        const parameters = { KeyOne: duplicateValue, KeyTwo: duplicateValue };
+        return Template.loadYaml(yamldata)
+            .then((tmpl) => {
+                assert.throws(() => tmpl.render(parameters), /Error: parameters must have unique values. The parameter value "duplicate_key" is duplicated across parameters and you must update the parameter values to ensure they are unique./);
+            });
+    });
     it('schema_nested_sections', function () {
         const ymldata = `
             definitions:


### PR DESCRIPTION
If a mustache view contains data that will cause duplicate keys in the rendered template, when f5-fast-core enters post-processing, yaml.load will return an error similar to:
```
duplicated mapping key (41:13)

38 |
39 |
40 |
41 |             \"shouldDup\": {
------------------^
42 |                 \"pool\": \"shouldDup\",
43 |               \"persistenceMethods\": [],
``` 
The error does not contain enough context for a end-user to understand how to resolve the duplicate keys on their own.

On a duplicate mapping key error, this change updates the error message to be similar to:
```
parameters must have unique values. The parameter value "shouldDup" is duplicated across parameters and you must update the parameter values to ensure they are unique.
```

Additional changes in this MR:
- rolled back Axios to ^0.27.2
- update to package lock to resolve npm vulnerabilities